### PR TITLE
Update requirements and move backup-pruner to group vars.

### DIFF
--- a/group_vars/backup-pruner/public.yml
+++ b/group_vars/backup-pruner/public.yml
@@ -1,6 +1,3 @@
-FORWARD_MAIL_RELAY_MAIL_TO: "ops@example.com"
-FORWARD_MAIL_SMTP_FROM: "{{ FORWARD_MAIL_RELAY_MAIL_TO }}"
-
 TARSNAPPER_CONF: /etc/tarsnapper.yml
 JOB_LOG: /var/log/backup-pruner-summary.log
 LOG_DIR: /var/log/backup-pruner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 ansible==2.3.2
 netaddr==0.7.19
-cryptography==1.3.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,13 +1,12 @@
 # Note: due to security concerns we prefer using git hashes than ansible versions.
 
-# Our fork of security, can be synced when this is merged: https://github.com/geerlingguy/ansible-role-security/pull/16
 - name: geerlingguy.security
-  src: https://github.com/open-craft/ansible-role-security
-  version: 'origin/jbzdak/notify-mail'
+  src: https://github.com/geerlingguy/ansible-role-security
+  version: af8b13833290ccae2ce1d2c9cce78862ddd3666c
 
 - name: geerlingguy.nginx
   src: https://github.com/geerlingguy/ansible-role-nginx
-  version: 'e81825546577cfb300efbcaec32aae4716561385'
+  version: e81825546577cfb300efbcaec32aae4716561385
 
 - name: kamaln7.swapfile
   src: https://github.com/kamaln7/ansible-swapfile
@@ -15,7 +14,7 @@
 
 - name: pmbauer.tarsnap
   src: https://github.com/pmbauer/ansible-tarsnap
-  version: origin/master
+  version: 7a625912409a0be2a3bf48967c60c5328ae2f3b2
 
 - name: backup-to-tarsnap
   src: https://github.com/open-craft/ansible-backup-to-tarsnap


### PR DESCRIPTION
This PR makes the following fixes:

1. Moves the backup-pruner variables that were in `host_vars` to `group_vars`.
1. Removes unnecessary `cryptography==1.3.1`.
1. Updates the `ansible-role-security` to use the latest upstream master -- I checked the commit history since the commit we were using, and it is mostly just doc/test fixes & updates, and https://github.com/geerlingguy/ansible-role-security/commit/2abe44e34386f66633dd512d8a286e413c232d3f which adds the optional `security_autoupdate_blacklist`.
1. Updates the `ansible-tarsnap` to use a commit hash rather than a branch since it's an external role.