### PR TITLE
Remove extraneous variable override, and add bootstrap template

### DIFF
--- a/bootstrap-dedicated.yml
+++ b/bootstrap-dedicated.yml
@@ -1,0 +1,47 @@
+---
+# Playbook to bootstrap the SoYouStart dedicated servers.  These servers don't have a non-root user
+# account when freshly installed.  Running our playbooks as the root user is not an option, since
+# geerlingguy.security role disables root login, so we would lock ourselves out.  This playbook
+# creates the ubuntu user, gives it the required permissions and disables the password of the root
+# user.  The ubuntu user is made accessible with the SSH private key used to run this playbook.
+#
+# Usage:
+#    ansible-playbook bootstrap-dedicated.yml -i <IP address or hostname>, \
+#        --private-key=/path/to/ssh/private/key
+#
+# Note that the comma after the IP address needs to be included.
+
+- name: prepare dedicated servers
+  hosts: all
+  vars:
+    ansible_user: root
+  become: false
+  tasks:
+    - name: create ubuntu user
+      user:
+        name: ubuntu
+        groups: adm,sudo
+        shell: /bin/bash
+
+    - name: give passwordless sudo privileges to ubuntu user
+      copy:
+        content: |
+          ubuntu ALL=(ALL) NOPASSWD:ALL
+        dest: /etc/sudoers.d/ubuntu_user
+        mode: 0440
+
+    - name: generate SSH public key
+      local_action: >
+        command ssh-keygen -y -f {{ ansible_ssh_private_key_file }}
+      register: common_public_ssh_key
+
+    - name: add SSH authorized key for user ubuntu
+      authorized_key:
+        user: ubuntu
+        key: "{{ common_public_ssh_key.stdout }}"
+
+    - name: disable root password
+      user:
+        name: root
+        password: "*"
+        update_password: always

--- a/group_vars/postgres/public.yml
+++ b/group_vars/postgres/public.yml
@@ -1,6 +1,5 @@
 POSTGRES_SERVER_DOMAIN: "{{ inventory_hostname }}"
 
-POSTGRES_SERVER_BACKUP_DIR: "/var/lib/postgres/backup"
 TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/backup-pre.sh"
 TARSNAP_BACKUP_POST_SCRIPT: "/usr/local/sbin/backup-post.sh"
 TARSNAP_BACKUP_FOLDERS: "{{ POSTGRES_SERVER_BACKUP_DIR }}"


### PR DESCRIPTION
This PR contains a fix where the backup directory was erroneously overrode, causing disks to fill early.

It also moves a playbook into the public repo as it did not contain any secrets.