### PR TITLE
Add playbook for the accounting application.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -1,5 +1,5 @@
 - name: Install Python 2
-  hosts: load-balancer:rabbitmq:elasticsearch:relay:chat:mongodb:backup-prune
+  hosts: accounting:backup-prune:chat:elasticsearch:load-balancer:mongodb:rabbitmq:relay
   become: true
   gather_facts: false
   tasks:
@@ -107,3 +107,13 @@
     - mattermost
     - crafty
     - link-shortener
+
+- name: Set up OpenCraft Accounting Automation application
+  hosts: accounting
+  become: true
+  roles:
+    - common-server
+    - forward-server-mail
+    - geerlingguy.nginx
+    - geerlingguy.certbot
+    - accounting

--- a/group_vars/accounting/public.yml
+++ b/group_vars/accounting/public.yml
@@ -1,0 +1,15 @@
+---
+
+COMMON_SERVER_NO_BACKUPS: true
+
+# Snitches
+SANITY_CHECK_LIVE_PORTS:
+  - host: localhost
+    port: 443
+    message: "Cannot connect to HTTPS port."
+  - host: localhost
+    port: 1786
+    message: "Accounting API is not responding on port 1786."
+
+# NGINX
+nginx_remove_default_vhost: true

--- a/group_vars/all/public.yml
+++ b/group_vars/all/public.yml
@@ -1,8 +1,13 @@
+# Tarsnap
 tarsnap_version: 1.0.37
 tarsnap_cache: /var/tarsnap/cache
 tarsnap_cron_hour: "*"
 tarsnap_tarsnapper_conf: "{{ playbook_dir }}/opencraft-roles/roles/tarsnap/files/conf/tarsnapper.{{ inventory_hostname }}.conf"
 
+# Email
 FORWARD_MAIL_RELAY_MAIL_TO: '{{ OPS_EMAIL }}'
 COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: '{{ OPS_EMAIL }}'
 security_autoupdate_mail_to: '{{ OPS_EMAIL }}'
+
+# Certbot
+certbot_auto_renew_user: root

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,6 +8,11 @@
   src: https://github.com/geerlingguy/ansible-role-nginx
   version: e81825546577cfb300efbcaec32aae4716561385
 
+# Any version after this requires Ansible >= 2.4.
+- name: geerlingguy.certbot
+  src: https://github.com/geerlingguy/ansible-role-certbot
+  version: 574c0843c8620f299ff67acbf35c9a6aa45121d0
+
 - name: kamaln7.swapfile
   src: https://github.com/kamaln7/ansible-swapfile
   version: 8eb0e18d90a7f25b6658fbf56bcba01b84a664fc
@@ -72,6 +77,10 @@
   src: https://github.com/open-craft/ansible-link-shortener
   version: origin/master
 
+- name: accounting
+  src: https://github.com/open-craft/ansible-accounting
+  version: origin/master
+
 - name: geerlingguy.mysql
   src: https://github.com/geerlingguy/ansible-role-mysql
   version: c71ded56d87c8df606210b59f045ed4c3f1f98ff
@@ -95,4 +104,3 @@
 - name: greendayonfire.mongodb
   src: https://github.com/UnderGreen/ansible-role-mongodb
   version: 1ba531c5c68a4cf684410c50e7286ffd7742b848
-


### PR DESCRIPTION
Adds the playbook that'll run the necessary roles for deploying the [Accounting Automation](https://github.com/open-craft/accounting) service.

See https://github.com/open-craft/ansible-secrets-accounting/pull/1 for actual test instructions.

# BEFORE MERGE

**Make sure to change to use the `master` branch for the role**.