### PR TITLE
Dedicated servers should not set up a swapfile.

### DIFF
--- a/group_vars/all/public.yml
+++ b/group_vars/all/public.yml
@@ -11,3 +11,6 @@ security_autoupdate_mail_to: '{{ OPS_EMAIL }}'
 
 # Certbot
 certbot_auto_renew_user: root
+
+# swapfile
+swapfile_size: "{{ '512MB' if (dedicated_server is undefined or not dedicated_server) else false }}"


### PR DESCRIPTION
When running on dedicated servers, a swapfile should not be created. 

**Testing instructions**:
Testing this pull request requires setting up an unused server and running the dedicated server playbook on it. After running the playbook there should not be any swapfile set up on the server.

**Reviewers**
- [ ] @smarnach 