### PR TITLE
Add RabbitMQ node health check

### DIFF
--- a/group_vars/rabbitmq/public.yml
+++ b/group_vars/rabbitmq/public.yml
@@ -6,5 +6,9 @@ SANITY_CHECK_LIVE_PORTS:
     port: 15671
     message: "RabbitMQ management does not respond on port 15671."
 
+SANITY_CHECK_COMMANDS:
+  - command: /usr/sbin/rabbitmqctl node_health_check
+    message: "RabbitMQ health check not passing"
+
 TARSNAP_BACKUP_FOLDERS: "{{ RABBITMQ_EXPORT_DIR }} /etc/rabbitmq /etc/letsencrypt"
 TARSNAP_BACKUP_PRE_SCRIPT: "{{ RABBITMQ_SCRIPTS_DIR }}/{{ RABBITMQ_BACKUP_COMMAND }}"


### PR DESCRIPTION
This adds a command that checks whether rabbitmq passes the health check. If the connection fails for any other reason, the output won't contain the desired message, the `grep` will fail and an error e-mail will be sent by [sanity-checker](https://github.com/open-craft/ansible-sanity-checker).
