### PR TITLE
Set open table cache size to 200,000 for MySQL

### DIFF
--- a/group_vars/mysql/public.yml
+++ b/group_vars/mysql/public.yml
@@ -12,6 +12,8 @@ mysql_packages:
   - mysql-server-5.5
   - mysql-client-5.5
 
+mysql_table_open_cache: 200000
+
 FORWARD_MAIL_MYDOMAIN: "{{ MYSQL_SERVER_DOMAIN }}"
 UNATTENED_UPGRADES_ERRORS_RELAY_TO: "{{ MYSQL_SERVER_DOMAIN }}"
 


### PR DESCRIPTION
This sets the variable `mysql_table_open_cache`, since we generally have a very high number of open tables. This may help alleviate some of the performance issues we've been seeing with MySQL lately.