### PR TITLE
Add nginx to load balancer config to serve error pages

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -73,6 +73,7 @@
   roles:
     - common-server
     - forward-server-mail
+    - geerlingguy.nginx
     - load-balancer
 
 - name: Set up rabbitmq servers


### PR DESCRIPTION
This pull request adds the Nginx role to the load balancer to serve maintenance pages from the load balancer itself.