### PR TITLE
Update instructions for MySQL setup, and version of ansible-role-mysql to use our fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,19 +215,15 @@ This ansible repository deploys MySQL server on OpenStack provider.
    data will be stored elsewhere.
 1. Attach the data volume that you created earlier to the VM (go to `Volumes` -> data volume -> expand dropdown next to "Edit Volume" ->
    `Edit Attachments`).
-1. Manual step: SSH into the database instance and format `/dev/vdb` using `ext4`.
-   Run `fdisk /dev/vdb` to do this and then issue:
-    1. `o` --- creates new DOS partition table
-    1. `n p` --- creates primary partition, and then `1 <enter> <enter>` will create partition in slot 1 that will span the whole disk.
-    1. `w` --- writes changes to the disk
-    1. Create the file system: `mkfs.ext4 -j /dev/vdb1`
+1. Manual step: SSH into the database instance and format `/dev/vdb` using `zfs`.
+    1. Create the zfs pool: `zpool create -m /var/lib/mysql mysql /dev/vdb`
 1. Go to info page and note the instance public key, ssh to the instance and check whether public key matches,
    save public key to your ssh config.
 
 ### Generate secrets
 
 1. Create `private-extra-vars.yml`, you'll put all the generated variables there
-1. Generate root password, put it in the `private.yaml` for your host, under `MYSQL_ROOT_PASSWORD`.
+1. Generate root password, put it in the `private.yaml` for your host, under `mysql_root_password`.
 1. Create a key, but store it somewhere safe (for example keepassx database), this key shouldn't end on the mysql server.
 1. Generate tarsnap read write key from the master key, see [tarsnap-keymngmt](http://www.tarsnap.com/man-tarsnap-keymgmt.1.html),
    save this key in `MYSQL_TARSNAP_KEY`. **Note**: this key won't be able to delete the backups.

--- a/group_vars/mysql/public.yml
+++ b/group_vars/mysql/public.yml
@@ -10,6 +10,9 @@ mysql_packages:
   - mysql-server-5.5
   - mysql-client-5.5
 
+mysql_table_open_cache: 200000
+mysql_skip_name_resolve: true
+
 # TARSNAP #####################################################################
 
 TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/backup-pre.sh"

--- a/requirements.yml
+++ b/requirements.yml
@@ -86,8 +86,8 @@
   version: origin/master
 
 - name: geerlingguy.mysql
-  src: https://github.com/geerlingguy/ansible-role-mysql
-  version: c71ded56d87c8df606210b59f045ed4c3f1f98ff
+  src: https://github.com/open-craft/ansible-role-mysql
+  version: 03358d3f180b2e6ffa2a5084f794e09f71884de5
 
 - name: mysql
   src: https://github.com/open-craft/ansible-mysql


### PR DESCRIPTION
This Pull Request updates the instructions for setting up a MySQL server, and also updates the required `ansible-role-mysql` to use our fork which now has added support for GTID redundancy.

**JIRA tickets**: OC-3959

**Reviewers**
- [ ] (tomaszgy)