### PR TITLE
Make name consistent with group vars folder name.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -1,12 +1,12 @@
 - name: Install Python 2
-  hosts: accounting:backup-prune:chat:elasticsearch:load-balancer:mongodb:rabbitmq:relay:postgres
+  hosts: accounting:backup-pruner:chat:elasticsearch:load-balancer:mongodb:rabbitmq:relay:postgres
   become: true
   gather_facts: false
   tasks:
     - raw: "[ -e /usr/bin/python ] || sudo apt-get update -qq && sudo apt-get install -qq python"
 
 - name: Set up backup-prune server
-  hosts: backup-prune
+  hosts: backup-pruner
   become: true
   roles:
     - name: common-server
@@ -15,7 +15,7 @@
     - name: 'pmbauer.tarsnap'
 
 - name: Install backup pruner
-  hosts: backup-prune
+  hosts: backup-pruner
   become: true
   tasks:
     - include: backup-pruner.yml


### PR DESCRIPTION
Mismatches between using `backup-prune` and `backup-pruner` caused running the backup prune playbook to fail. This makes all occurrences consistent on `backup-pruner`, and the playbook succeeds.

Connected to https://github.com/open-craft/ansible-secrets/pull/21

(https://tasks.opencraft.com/browse/OC-4234)