### PR TITLE
Disable Certbot installation for some groups.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -1,5 +1,5 @@
 - name: Install Python 2
-  hosts: accounting:backup-pruner:chat:elasticsearch:load-balancer:mongodb:rabbitmq:relay:postgres
+  hosts: all
   become: true
   gather_facts: false
   tasks:
@@ -120,6 +120,4 @@
   roles:
     - common-server
     - forward-server-mail
-    - geerlingguy.nginx
-    - geerlingguy.certbot
     - accounting

--- a/group_vars/accounting/public.yml
+++ b/group_vars/accounting/public.yml
@@ -13,11 +13,3 @@ SANITY_CHECK_LIVE_PORTS:
   - host: localhost
     port: 1786
     message: "Accounting API is not responding on port 1786."
-
-# NGINX #######################################################################
-
-nginx_remove_default_vhost: true
-
-# CERTBOT #####################################################################
-
-certbot_auto_renew_options: "--quiet --no-self-upgrade --pre-hook 'service nginx stop' --post-hook 'service nginx start'"

--- a/group_vars/all/public.yml
+++ b/group_vars/all/public.yml
@@ -5,12 +5,11 @@
 tarsnap_version: 1.0.37
 tarsnap_cache: /var/tarsnap/cache
 tarsnap_cron_hour: "*"
-tarsnap_tarsnapper_conf: "{{ playbook_dir }}/opencraft-roles/roles/tarsnap/files/conf/tarsnapper.{{ inventory_hostname }}.conf"
 
 # MAIL ########################################################################
 
 FORWARD_MAIL_RELAY_MAIL_TO: '{{ OPS_EMAIL }}'
-COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: '{{ OPS_EMAIL }}'
+COMMON_SERVER_OPS_EMAIL: '{{ OPS_EMAIL }}'
 security_autoupdate_mail_to: '{{ OPS_EMAIL }}'
 
 # CERTBOT #####################################################################

--- a/group_vars/dalite/public.yml
+++ b/group_vars/dalite/public.yml
@@ -1,3 +1,5 @@
+COMMON_SERVER_INSTALL_CERTBOT: false
+
 DALITE_SERVER_DOMAIN: '{{ inventory_hostname }}'
 
 DALITE_REPOSITORY_VERSION: "master"

--- a/group_vars/load-balancer/public.yml
+++ b/group_vars/load-balancer/public.yml
@@ -3,6 +3,7 @@
 # GENERAL #####################################################################
 
 LOAD_BALANCER_SERVER_IP: "{{ COMMON_FLOATING_IP or ansible_host }}"
+COMMON_SERVER_INSTALL_CERTBOT: false
 
 # SANITY ######################################################################
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,15 +4,6 @@
   src: https://github.com/geerlingguy/ansible-role-security
   version: af8b13833290ccae2ce1d2c9cce78862ddd3666c
 
-- name: geerlingguy.nginx
-  src: https://github.com/geerlingguy/ansible-role-nginx
-  version: e81825546577cfb300efbcaec32aae4716561385
-
-# Any version after this requires Ansible >= 2.4.
-- name: geerlingguy.certbot
-  src: https://github.com/geerlingguy/ansible-role-certbot
-  version: 574c0843c8620f299ff67acbf35c9a6aa45121d0
-
 - name: kamaln7.swapfile
   src: https://github.com/kamaln7/ansible-swapfile
   version: 8eb0e18d90a7f25b6658fbf56bcba01b84a664fc


### PR DESCRIPTION
The Certbot installation introduced in https://github.com/open-craft/ansible-common-server/pull/15 conflicts with the load-balancer role, so we need to disable it for the load balancers.  We also disable it for the Dalite server, since the corresponding role hasn't been fully migrated yet.

This PR should be merged after the following PRs:
* https://github.com/open-craft/ansible-common-server/pull/15
* https://github.com/open-craft/ansible-dalite/pull/6
* https://github.com/open-craft/ansible-load-balancer/pull/21
* https://github.com/open-craft/ansible-rabbitmq/pull/11
* https://github.com/open-craft/ansible-mattermost/pull/4
* https://github.com/open-craft/ansible-link-shortener/pull/2
* https://github.com/open-craft/ansible-accounting/pull/3
* https://gitlab.com/opencraft/dev/link-shortener/merge_requests/4

This PR also removes the Tarsnapper configuration file setting we had in place for all servers.  Tarsnapper is only needed on the backup-pruner, so this setting was some relic from the initial development of the Ansible infrastructure.

Before merging, the changes to `requirements.yml` need to be reverted.  After merging, the submodule hash in the secrets repo needs to be updated.