### PR TITLE
Move node-exporter role to the end of the play for some servers.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -66,6 +66,7 @@
     - forward-server-mail
     - dalite
     - backup-swift-container
+    - node-exporter
 
 - name: Set up load-balancing servers
   hosts: load-balancer
@@ -74,6 +75,7 @@
     - common-server
     - forward-server-mail
     - load-balancer
+    - node-exporter
 
 - name: Set up rabbitmq servers
   hosts: rabbitmq

--- a/group_vars/dalite/public.yml
+++ b/group_vars/dalite/public.yml
@@ -1,5 +1,9 @@
 COMMON_SERVER_INSTALL_CERTBOT: false
 COMMON_SERVER_INSTALL_CONSUL: false
+COMMON_SERVER_INSTALL_NODE_EXPORTER: false
+
+NODE_EXPORTER_SSL_CERT: /etc/ssl/certs/ssl-cert.pem
+NODE_EXPORTER_SSL_KEY: /etc/ssl/private/ssl-cert.key
 
 DALITE_SERVER_DOMAIN: '{{ inventory_hostname }}'
 

--- a/group_vars/load-balancer/public.yml
+++ b/group_vars/load-balancer/public.yml
@@ -4,6 +4,7 @@
 
 LOAD_BALANCER_SERVER_IP: "{{ COMMON_FLOATING_IP or ansible_host }}"
 COMMON_SERVER_INSTALL_CERTBOT: false
+COMMON_SERVER_INSTALL_NODE_EXPORTER: false
 
 # SANITY ######################################################################
 


### PR DESCRIPTION
As usual, we need to revert the changes to requirements.yml before merging, and update the submodule hash after merging.