### PR TITLE
Add filebeat role.

### DIFF
--- a/playbooks/appserver.yml
+++ b/playbooks/appserver.yml
@@ -9,3 +9,7 @@
       when: consul_servers | length > 0
     - role: node-exporter
       when: NODE_EXPORTER_PASSWORD != 'set-me-please'
+    - role: filebeat
+      # Appservers may have some Elastic stuff already installed on them.
+      filebeat_elastic_apt_pin: 200
+      when: filebeat_logstash_hosts | length > 0

--- a/playbooks/group_vars/accounting/public.yml
+++ b/playbooks/group_vars/accounting/public.yml
@@ -14,3 +14,11 @@ SANITY_CHECK_LIVE_PORTS:
   - host: localhost
     port: 1786
     message: "Accounting API is not responding on port 1786."
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "accounting"
+    paths:
+      - /var/www/accounting/log/accounting.*.log

--- a/playbooks/group_vars/backup-pruner/public.yml
+++ b/playbooks/group_vars/backup-pruner/public.yml
@@ -1,2 +1,14 @@
+---
+
+# COMMON ######################################################################
+
 COMMON_SERVER_NO_BACKUPS: true
 COMMON_SERVER_INSTALL_CONSUL: false
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "backup-pruner"
+    paths:
+      - "{{ BACKUP_PRUNER_LOG_DIR }}/*.log"

--- a/playbooks/group_vars/chat/public.yml
+++ b/playbooks/group_vars/chat/public.yml
@@ -8,3 +8,11 @@ SANITY_CHECK_LIVE_PORTS:
     message: "Cannot connect to HTTPS port."
 
 MATTERMOST_OPS_EMAIL: "{{ OPS_EMAIL }}"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "mattermost"
+    paths:
+      - "{{ MATTERMOST_LOG_DIR }}/*.log"

--- a/playbooks/group_vars/dalite/public.yml
+++ b/playbooks/group_vars/dalite/public.yml
@@ -49,3 +49,11 @@ BACKUP_SWIFT_DEST: '/usr/local/sbin/backup-container.sh'
 BACKUP_SWIFT_CACHE: "/var/cache/tarsnap-swift"
 BACKUP_SWIFT_TARSNAP_KEY: "{{ DALITE_TARSNAP_SWIFT }}"
 BACKUP_SWIFT_RC: "{{ DALITE_SWIFT_BACKUP_RC }}"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "dalite"
+    paths:
+      - "{{ DALITE_LOG_DIR }}/*.log"

--- a/playbooks/group_vars/elasticsearch/public.yml
+++ b/playbooks/group_vars/elasticsearch/public.yml
@@ -21,3 +21,11 @@ consul_service_config:
       - name: "Connect to Elasticsearch"
         tcp: "{{ inventory_hostname }}:9200"
         interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "elasticsearch"
+    paths:
+      - "{{ elasticsearch_log_dir }}/*.log"

--- a/playbooks/group_vars/load-balancer/public.yml
+++ b/playbooks/group_vars/load-balancer/public.yml
@@ -53,3 +53,11 @@ consul_service_config:
         - name: "Connect to HAProxy HTTPS"
           tcp: "{{ LOAD_BALANCER_SERVER_IP }}:443"
           interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "haproxy"
+    paths:
+      - /var/log/haproxy.log

--- a/playbooks/group_vars/mongodb/public.yml
+++ b/playbooks/group_vars/mongodb/public.yml
@@ -13,7 +13,7 @@ mongodb_storage_dbpath: "/var/lib/mongodb"
 # is using 14 GB for the module store.)
 mongodb_storage_engine: 'mmapv1'
 mongodb_storage_quota_maxfiles: 36
-mongodb_systemlog_path: "/var/lib/mongodb/log/{{ mongodb_daemon_name }}.log"
+mongodb_systemlog_path: "{{ mongodb_storage_dbpath }}/log/{{ mongodb_daemon_name }}.log"
 mongodb_pymongo_from_pip: true
 
 MONGODB_SERVER_DOMAIN: "{{ inventory_hostname }}"
@@ -53,3 +53,11 @@ consul_service_config:
       - name: "Connect to MongoDB"
         tcp: "{{ MONGODB_SERVER_DOMAIN }}:27017"
         interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "mongodb"
+    paths:
+      - "{{ mongodb_systemlog_path | dirname }}/*.log*"

--- a/playbooks/group_vars/mysql/public.yml
+++ b/playbooks/group_vars/mysql/public.yml
@@ -6,12 +6,10 @@ MYSQL_SERVER_DOMAIN: "{{ inventory_hostname }}"
 MYSQL_SERVER_BACKUP_DIR: '/var/lib/mysql/backup'
 mysql_root_password_update: true
 mysql_table_open_cache: 200000
+mysql_skip_name_resolve: true
 mysql_packages:
   - mysql-server-5.5
   - mysql-client-5.5
-
-mysql_table_open_cache: 200000
-mysql_skip_name_resolve: true
 
 # TARSNAP #####################################################################
 
@@ -45,3 +43,11 @@ consul_service_config:
       - name: "Connect to MySQL"
         tcp: "{{ MYSQL_SERVER_DOMAIN }}:3306"
         interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "mysql"
+    paths:
+      - /var/log/mysql.*

--- a/playbooks/group_vars/ocim/public.yml
+++ b/playbooks/group_vars/ocim/public.yml
@@ -1,6 +1,33 @@
+---
+
+# COMMON ######################################################################
+
 COMMON_SERVER_NO_BACKUPS: true
 COMMON_SERVER_INSTALL_CERTBOT: false
 COMMON_SERVER_INSTALL_NODE_EXPORTER: false
 
+# PROMETHEUS ##################################################################
+
 NODE_EXPORTER_SSL_CERT: /etc/ssl/certs/ssl-cert.pem
 NODE_EXPORTER_SSL_KEY: /etc/ssl/private/ssl-cert.key
+
+# CONSUL ######################################################################
+
+consul_service_config:
+  service:
+    name: "ocim"
+    tags: ["ocim"]
+    port: 443
+    enable_tag_override: true
+    checks:
+      - name: "Connect to Ocim HTTPS"
+        tcp: "{{ OPENCRAFT_DOMAIN_NAME }}:443"
+        interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "ocim"
+    paths:
+      - "{{ opencraft_root_dir }}/log/im.*.log"

--- a/playbooks/group_vars/postgres/public.yml
+++ b/playbooks/group_vars/postgres/public.yml
@@ -56,3 +56,11 @@ consul_service_config:
       - name: "Connect to PostgreSQL"
         tcp: "{{ POSTGRES_SERVER_DOMAIN }}:5432"
         interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "postgres"
+    paths:
+      - /var/log/postgresql/*.log

--- a/playbooks/group_vars/rabbitmq/public.yml
+++ b/playbooks/group_vars/rabbitmq/public.yml
@@ -41,3 +41,15 @@ consul_service_config:
         - name: "Connect to RabbitMQ Management Interface"
           tcp: "{{ inventory_hostname }}:15671"
           interval: "10m"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "rabbitmq"
+    paths:
+      - /var/log/rabbitmq/*.log
+    multiline:
+      pattern: '^='
+      match: after
+      negate: true

--- a/playbooks/group_vars/relay/public.yml
+++ b/playbooks/group_vars/relay/public.yml
@@ -1,11 +1,19 @@
 ---
+
+# COMMON ######################################################################
+
 COMMON_SERVER_NO_BACKUPS: true
 COMMON_SERVER_INSTALL_CONSUL: false
 COMMON_SERVER_INSTALL_POSTFIX: false
+COMMON_SERVER_INSTALL_FILEBEAT: false
+
+# SANITY ######################################################################
 
 SANITY_CHECK_LIVE_PORTS:
   - host: localhost
     port: 25
     message: "Cannot connect to SMTP port."
+
+# MAIL ########################################################################
 
 POSTFIX_OPS_EMAIL: "{{ OPS_EMAIL }}"

--- a/playbooks/roles/common-server/defaults/main.yml
+++ b/playbooks/roles/common-server/defaults/main.yml
@@ -103,3 +103,6 @@ COMMON_SERVER_INSTALL_NODE_EXPORTER: true
 
 # Install Postfix to forward local mail
 COMMON_SERVER_INSTALL_POSTFIX: true
+
+# Filebeat
+COMMON_SERVER_INSTALL_FILEBEAT: true

--- a/playbooks/roles/common-server/meta/main.yml
+++ b/playbooks/roles/common-server/meta/main.yml
@@ -13,3 +13,5 @@ dependencies:
     when: COMMON_SERVER_INSTALL_NODE_EXPORTER
   - name: forward-server-mail
     when: COMMON_SERVER_INSTALL_POSTFIX
+  - name: filebeat
+    when: COMMON_SERVER_INSTALL_FILEBEAT

--- a/playbooks/roles/filebeat/README.md
+++ b/playbooks/roles/filebeat/README.md
@@ -1,0 +1,28 @@
+Filebeat
+========
+
+This role installs Filebeat on the server for log forwarding purposes.
+
+You can configure the role to send any logs to any logstash endpoint.
+
+Requirements
+------------
+
+N/A
+
+Role Variables
+--------------
+
+See `defaults/main.yml`.
+
+Dependencies
+------------
+
+N/A
+
+Example Playbook
+----------------
+
+    - hosts: all
+      roles:
+         - filebeat

--- a/playbooks/roles/filebeat/defaults/main.yml
+++ b/playbooks/roles/filebeat/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+
+filebeat_elastic_apt_pin: 500
+filebeat_config_dir: /etc/filebeat
+filebeat_ca_cert_url: ""
+filebeat_ca_cert: ""
+filebeat_ca_path: "{{ filebeat_config_dir }}/ca.crt"
+filebeat_registry_file: /var/lib/filebeat/registry
+filebeat_logstash_hosts: []
+filebeat_logstash:
+  hosts: "{{ filebeat_logstash_hosts }}"
+  ssl:
+    certificate_authorities: ["{{ filebeat_ca_path }}"]
+
+filebeat_common_prospector_fields:
+  type: service
+  host: "{{ inventory_hostname }}"
+
+filebeat_common_prospector:
+  fields_under_root: true
+  encoding: utf-8
+  ignore_older: 3h
+  paths:
+    - /var/log/*.log
+  fields: "{{ filebeat_common_prospector_fields }}"
+
+filebeat_prospectors: []

--- a/playbooks/roles/filebeat/handlers/main.yml
+++ b/playbooks/roles/filebeat/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: restart filebeat
+  service:
+    name: filebeat
+    state: restarted

--- a/playbooks/roles/filebeat/tasks/main.yml
+++ b/playbooks/roles/filebeat/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Install apt package dependencies.
+  apt:
+    name: apt-transport-https
+    state: present
+
+- name: Add Elastic's apt key
+  apt_key:
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Elastic apt repository pin
+  template:
+    src: elastic.preferences.j2
+    dest: "/etc/apt/preferences.d/artifacts_elastic_co_packages_6_x_apt"
+
+- name: Add Elastic's apt repository
+  apt_repository:
+    repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
+    state: present
+    update_cache: yes
+
+- name: Install Filebeat
+  apt:
+    name: filebeat
+    state: present
+
+- name: Install Filebeat configuration
+  template:
+    src: filebeat.yml.j2
+    dest: "{{ filebeat_config_dir }}/filebeat.yml"
+  notify:
+    - restart filebeat
+
+- name: Ensure Filebeat CA certificate variables are exclusive
+  assert:
+    that: filebeat_ca_cert == "" or filebeat_ca_cert_url == ""
+    msg: "Please set either `filebeat_ca_cert` or `filebeat_ca_cert_url`, but not both."
+
+- name: Install Filebeat CA certificate
+  copy:
+    content: "{{ filebeat_ca_cert }}"
+    dest: "{{ filebeat_ca_path }}"
+    owner: root
+    group: root
+    mode: 0400
+  when: filebeat_ca_cert != "" and filebeat_ca_cert_url == ""
+
+- name: Install Filebeat CA certificate from URL
+  get_url:
+    url: "{{ filebeat_ca_cert_url }}"
+    dest: "{{ filebeat_ca_path }}"
+    owner: root
+    group: root
+    mode: 0400
+  when: filebeat_ca_cert == "" and filebeat_ca_cert_url != ""
+
+- name: Ensure Filebeat is started and enabled at boot
+  service:
+    name: filebeat
+    state: started
+    enabled: yes

--- a/playbooks/roles/filebeat/templates/elastic.preferences.j2
+++ b/playbooks/roles/filebeat/templates/elastic.preferences.j2
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=elastic,a=stable,n=stable,l=. stable,c=main
+Pin-Priority: {{ filebeat_elastic_apt_pin }}

--- a/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -1,0 +1,11 @@
+filebeat:
+  registry_file: "{{ filebeat_registry_file }}"
+
+  prospectors:
+    {% for prospector in filebeat_prospectors %}
+- {{ filebeat_common_prospector | combine(prospector, recursive=True) | to_nice_yaml | indent(width=6) }}
+    {% endfor %}
+
+output:
+  logstash:
+{{ filebeat_logstash | to_nice_yaml | indent(width=4, first=True) }}


### PR DESCRIPTION
This adds the initial version of the Filebeat role, afresh.

Note that the config here is a little complex. But in exchange, the actual configuration needed for individual groups of servers is very tiny. Otherwise the diff could be much larger.