### PR TITLE
Only enable HTTP/2 when using SSL.

### DIFF
--- a/playbooks/roles/node-exporter/templates/nginx-node-exporter.j2
+++ b/playbooks/roles/node-exporter/templates/nginx-node-exporter.j2
@@ -1,5 +1,5 @@
 server {
-    listen 0.0.0.0:19100 {% if NODE_EXPORTER_USE_SSL %}ssl {% endif %}http2 default;
+    listen 0.0.0.0:19100 {% if NODE_EXPORTER_USE_SSL %}ssl http2 {% endif %}default;
     server_name _;
 
     {% if NODE_EXPORTER_USE_SSL -%}


### PR DESCRIPTION
HTTP/2 always uses SSL, so we can only enable it if we want to use SSL.