### PR TITLE
Add warning to Ocim's .env files.

### DIFF
--- a/playbooks/roles/ocim/templates/env.j2
+++ b/playbooks/roles/ocim/templates/env.j2
@@ -1,3 +1,6 @@
+### WARNING: ###
+# This file is managed via Ansible.  Manual changes to this file will be overwritten.
+################
 {% for var, value in opencraft_all_env_tokens.items()|sort %}
-{{ var }}='{{ value }}'
+{{ var }}={{ value | quote }}
 {% endfor %}


### PR DESCRIPTION
After posting on the forum today, I noticed that we probably add this warning to the `.env` file.  I also fixed the quoting while I was there.

I tested this by running

    ansible-playbook deploy/playbooks/ocim.yml -l stage --check --diff --start-at-task="Install the configuration/environment file"

from the secrets repo and looking at the diff.