### PR TITLE
Pin Filebeat's Elastic repo for Elasticsearch servers & tag everything

### DIFF
--- a/playbooks/accounting.yml
+++ b/playbooks/accounting.yml
@@ -6,5 +6,8 @@
   hosts: accounting
   become: true
   roles:
-    - common-server
-    - accounting
+    - role: common-server
+      tags: 'common-server'
+
+    - role: accounting
+      tags: 'accounting'

--- a/playbooks/backup-pruner.yml
+++ b/playbooks/backup-pruner.yml
@@ -5,6 +5,11 @@
   hosts: backup-pruner
   become: true
   roles:
-    - common-server
-    - pmbauer.tarsnap
-    - backup-pruner
+    - role: common-server
+      tags: 'common-server'
+
+    - role: pmbauer.tarsnap
+      tags: 'pmbauer.tarsnap'
+
+    - role: backup-pruner
+      tags: 'backup-pruner'

--- a/playbooks/chat.yml
+++ b/playbooks/chat.yml
@@ -5,7 +5,14 @@
   hosts: chat
   become: true
   roles:
-    - common-server
-    - mattermost
-    - crafty
-    - link-shortener
+    - role: common-server
+      tags: 'common-server'
+
+    - role: mattermost
+      tags: 'mattermost'
+
+    - role: crafty
+      tags: 'crafty'
+
+    - role: link-shortener
+      tags: 'link-shortener'

--- a/playbooks/dalite.yml
+++ b/playbooks/dalite.yml
@@ -6,7 +6,8 @@
   hosts: dalite
   become: true
   roles:
-    - name: common-server
+    - role: common-server
+      tags: 'common-server'
       TARSNAP_KEY: "{{ DALITE_LOGROTATE_TARSNAP_KEY }}"
       TARSNAP_KEY_REMOTE_LOCATION: "/root/tarsnap-logrotate.key"
       TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/dalite-pre-backup.sh"
@@ -18,6 +19,12 @@
       # Backup of logs is initiated by logrotate, which incidentally
       # also creates data to be backed up.
       TARSNAP_CRONTAB_STATE: "absent"
-    - dalite
-    - backup-swift-container
-    - node-exporter
+
+    - role: dalite
+      tags: 'dalite'
+
+    - role: backup-swift-container
+      tags: 'backup-swift-container'
+
+    - role: node-exporter
+      tags: 'node-exporter'

--- a/playbooks/elasticsearch.yml
+++ b/playbooks/elasticsearch.yml
@@ -5,5 +5,8 @@
   hosts: elasticsearch
   become: true
   roles:
-    - common-server
-    - elasticsearch
+    - role: common-server
+      tags: 'common-server'
+
+    - role: elasticsearch
+      tags: 'elasticsearch'

--- a/playbooks/group_vars/elasticsearch/public.yml
+++ b/playbooks/group_vars/elasticsearch/public.yml
@@ -24,6 +24,8 @@ consul_service_config:
 
 # FILEBEAT ####################################################################
 
+# We don't want to accidentally upgrade Elasticsearch.
+filebeat_elastic_apt_pin: 200
 filebeat_prospectors:
   - fields:
       type: "elasticsearch"

--- a/playbooks/load-balancer.yml
+++ b/playbooks/load-balancer.yml
@@ -5,6 +5,11 @@
   hosts: load-balancer
   become: true
   roles:
-    - common-server
-    - load-balancer
-    - node-exporter
+    - role: common-server
+      tags: 'common-server'
+
+    - role: load-balancer
+      tags: 'load-balancer'
+
+    - role: node-exporter
+      tags: 'node-exporter'

--- a/playbooks/mongodb.yml
+++ b/playbooks/mongodb.yml
@@ -5,6 +5,11 @@
   hosts: mongodb
   become: true
   roles:
-    - common-server
-    - mongodb
-    - greendayonfire.mongodb
+    - role: common-server
+      tags: 'common-server'
+
+    - role: mongodb
+      tags: 'mongodb'
+
+    - role: greendayonfire.mongodb
+      tags: 'greendayonfire.mongodb'

--- a/playbooks/mysql.yml
+++ b/playbooks/mysql.yml
@@ -5,6 +5,11 @@
   hosts: mysql
   become: true
   roles:
-    - common-server
-    - mysql
-    - geerlingguy.mysql
+    - role: common-server
+      tags: 'common-server'
+
+    - role: mysql
+      tags: 'mysql'
+
+    - role: geerlingguy.mysql
+      tags: 'geerlingguy.mysql'

--- a/playbooks/ocim.yml
+++ b/playbooks/ocim.yml
@@ -3,6 +3,11 @@
   hosts: ocim
   become: true
   roles:
-    - common-server
-    - ocim
-    - node-exporter
+    - role: common-server
+      tags: 'common-server'
+
+    - role: ocim
+      tags: 'ocim'
+
+    - role: node-exporter
+      tags: 'node-exporter'

--- a/playbooks/postgres.yml
+++ b/playbooks/postgres.yml
@@ -5,6 +5,11 @@
   hosts: postgres
   become: true
   roles:
-    - common-server
-    - postgres
-    - geerlingguy.postgresql
+    - role: common-server
+      tags: 'common-server'
+
+    - role: postgres
+      tags: 'postgres'
+
+    - role: geerlingguy.postgresql
+      tags: 'geerlingguy.postgresql'

--- a/playbooks/rabbitmq.yml
+++ b/playbooks/rabbitmq.yml
@@ -5,5 +5,8 @@
   hosts: rabbitmq
   become: true
   roles:
-    - common-server
-    - rabbitmq
+    - role: common-server
+      tags: 'common-server'
+
+    - role: rabbitmq
+      tags: 'rabbitmq'

--- a/playbooks/relay.yml
+++ b/playbooks/relay.yml
@@ -5,5 +5,8 @@
   hosts: relay
   become: true
   roles:
-    - common-server
-    - postfix
+    - role: common-server
+      tags: 'common-server'
+
+    - role: postfix
+      tags: 'postfix'

--- a/playbooks/roles/common-server/meta/main.yml
+++ b/playbooks/roles/common-server/meta/main.yml
@@ -1,17 +1,36 @@
 dependencies:
   - name: common-server-init
+    tags: 'common-server-init'
+
   - name: kamaln7.swapfile
+    tags: 'kamaln7.swapfile'
+
   - name: geerlingguy.security
+    tags: 'geerlingguy.security'
+
   - name: sanity-checker
+    tags: 'sanity-checker'
+
   - name: backup-to-tarsnap
+    tags: 'backup-to-tarsnap'
     when: not COMMON_SERVER_NO_BACKUPS
+
   - name: certbot
+    tags: 'certbot'
     when: COMMON_SERVER_INSTALL_CERTBOT
+
   - name: consul
+    tags: 'consul'
     when: COMMON_SERVER_INSTALL_CONSUL
+
   - name: node-exporter
+    tags: 'node-exporter'
     when: COMMON_SERVER_INSTALL_NODE_EXPORTER
+
   - name: forward-server-mail
+    tags: 'forward-server-mail'
     when: COMMON_SERVER_INSTALL_POSTFIX
+
   - name: filebeat
+    tags: 'filebeat'
     when: COMMON_SERVER_INSTALL_FILEBEAT


### PR DESCRIPTION
When deploying Filebeat to all servers, I noticed I should probably pin the Elastic repo for Elasticsearch servers so they don't upgrade their Elasticsearch service accidentally to the latest version given by the Elastic 6.x apt repo.

Also, in order to run Filebeat alone on all servers without having to comment things out (which could cause issues with missing variables) and without having to use `--start-at-task` all the time (which requires us to eventually cancel the playbook mid-way), I tagged Filebeat with `'filebeat'` and ran `ansible-playbooks -vv deploy/playbooks/deploy-all.yml --tags "filebeat"` and only Filebeat ran on all servers without a problem. I then expanded this idea to every role in `common-server` plus all roles in playbooks.