### PR TITLE
Fix typo in Consul tag.

### DIFF
--- a/playbooks/roles/node-exporter/defaults/main.yml
+++ b/playbooks/roles/node-exporter/defaults/main.yml
@@ -14,6 +14,6 @@ NODE_EXPORTER_CONSUL_SERVICE:
     name: node-exporter
     tags:
       - node-exporter
-      - "{{ 'montitor-https' if NODE_EXPORTER_USE_SSL else 'monitor' }}"
+      - "{{ 'monitor-https' if NODE_EXPORTER_USE_SSL else 'monitor' }}"
     port: 19100
     enable_tag_override: true


### PR DESCRIPTION
There were multiple problems why Prometheus did not pick up the HTTPS targets, but this is the one that almost cost me my sanity, so it gets its own PR.  I specifically looked for typos in the tag names, multiple times, but I just didn't see it.