### PR TITLE
Copy nginx reload handler from common-server to nginx-proxy.

### DIFF
--- a/playbooks/roles/nginx-proxy/handlers/main.yml
+++ b/playbooks/roles/nginx-proxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded


### PR DESCRIPTION
The handler is also needed by the appserver playbook, where the common-server role is not available.