### PR TITLE
Disable backup lock for the Dalite logs backup.

### DIFF
--- a/playbooks/dalite.yml
+++ b/playbooks/dalite.yml
@@ -19,12 +19,13 @@
       # Backup of logs is initiated by logrotate, which incidentally
       # also creates data to be backed up.
       TARSNAP_CRONTAB_STATE: "absent"
+      # The backup lock is causing problems for Dalite, since the lock is inherited by
+      # gunicorn workers, which don't release it unless they are stopped.  Since the lock
+      # is not needed for a daily backup anyway, we simply disable it.
+      TARSNAP_BACKUP_GLOBAL_LOCK: false
 
     - role: dalite
       tags: 'dalite'
 
     - role: backup-swift-container
       tags: 'backup-swift-container'
-
-    - role: node-exporter
-      tags: 'node-exporter'

--- a/playbooks/group_vars/dalite/public.yml
+++ b/playbooks/group_vars/dalite/public.yml
@@ -1,5 +1,10 @@
+---
+# The Python 3 version on trusty is too old for Ansible.  We can remove this once we move to xenial.
+ansible_python_interpreter: /usr/bin/python
+
 COMMON_SERVER_INSTALL_CERTBOT: false
 COMMON_SERVER_INSTALL_CONSUL: false
+COMMON_SERVER_INSTALL_FILEBEAT: false
 COMMON_SERVER_INSTALL_NODE_EXPORTER: false
 
 NODE_EXPORTER_SSL_CERT: /etc/ssl/certs/ssl-cert.pem

--- a/playbooks/roles/backup-to-tarsnap/defaults/main.yml
+++ b/playbooks/roles/backup-to-tarsnap/defaults/main.yml
@@ -1,4 +1,4 @@
-
+---
 # Tarsnap key contents
 # Should look like
 # TARSNAP_KEY: |
@@ -24,6 +24,7 @@ TARSNAP_BACKUP_POST_SCRIPT: null
 TARSNAP_BACKUP_FOLDERS: null
 
 TARSNAP_BACKUP_SCRIPT_LOCATION: /usr/local/sbin/backup.sh
+TARSNAP_BACKUP_GLOBAL_LOCK: true
 
 # We will add timestamp to archive name
 TARSNAP_ARCHIVE_NAME: 'backup'

--- a/playbooks/roles/backup-to-tarsnap/templates/backup.sh
+++ b/playbooks/roles/backup-to-tarsnap/templates/backup.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
+{% if TARSNAP_BACKUP_GLOBAL_LOCK %}
 # Acquire backup lock using this script itself as the lockfile. If another
 # backup task is already running, then exit immediately.
 exec 200<$0
 flock -n 200 || { echo "Another backup task is already running."; exit 1; }
+{% endif %}
 
 # Logic is as follows:
 


### PR DESCRIPTION
This PR disables the lock for the logs backup, since it sometimes causes problems and is not needed.

The PR also removes some of the newer services, since the roles don't work on trusty, which the server is still running on.  It is already deployed to production.