### PR TITLE
Install service-specific exporters.

### DIFF
--- a/playbooks/group_vars/load-balancer/public.yml
+++ b/playbooks/group_vars/load-balancer/public.yml
@@ -71,3 +71,8 @@ filebeat_prospectors:
     paths:
       - /var/log/syslog
     include_lines: ['nomad']
+
+# PROMETHEUS ##################################################################
+
+HAPROXY_EXPORTER_ENABLED: true
+HAPROXY_EXPORTER_PASSWORD: "{{ NODE_EXPORTER_PASSWORD }}"

--- a/playbooks/group_vars/mongodb/public.yml
+++ b/playbooks/group_vars/mongodb/public.yml
@@ -24,6 +24,8 @@ MONGODB_SERVER_DOMAIN: "{{ inventory_hostname }}"
 
 MONGODB_SERVER_BACKUP_DIR: '/var/lib/mongodb/backup'
 
+MONGODB_EXPORTER_PASSWORD: "{{ NODE_EXPORTER_PASSWORD }}"
+
 # TARSNAP #####################################################################
 
 TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/backup-pre.sh"

--- a/playbooks/group_vars/mysql/public.yml
+++ b/playbooks/group_vars/mysql/public.yml
@@ -11,6 +11,8 @@ mysql_packages:
   - mysql-server-5.5
   - mysql-client-5.5
 
+MYSQL_EXPORTER_PASSWORD: "{{ NODE_EXPORTER_PASSWORD }}"
+
 # TARSNAP #####################################################################
 
 TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/backup-pre.sh"

--- a/playbooks/roles/consul/handlers/main.yml
+++ b/playbooks/roles/consul/handlers/main.yml
@@ -3,3 +3,6 @@
   service:
     name: consul
     state: restarted
+
+- name: reload consul
+  shell: "if command -v consul; then consul reload; fi"

--- a/playbooks/roles/mongodb/defaults/main.yml
+++ b/playbooks/roles/mongodb/defaults/main.yml
@@ -1,10 +1,17 @@
 ---
+
+# GENERAL #####################################################################
+
 MONGODB_OPENSTACK_DB_DEVICE: /dev/vdb1
 MONGODB_SERVER_BACKUP_DIR: /var/lib/mongodb/backup
 
+# PROMETHEUS ##################################################################
+
 MONGODB_EXPORTER_ENABLED: true
-MONGODB_EXPORTER_DOWNLOAD_URL: https://github.com/dcu/mongodb_exporter/releases/download/v1.0.0/mongodb_exporter-linux-amd64
+MONGODB_EXPORTER_VERSION: 1.0.0
+MONGODB_EXPORTER_DOWNLOAD_URL: https://github.com/dcu/mongodb_exporter/releases/download/v{{ MONGODB_EXPORTER_VERSION }}/mongodb_exporter-linux-amd64
 MONGODB_EXPORTER_PASSWORD: null
+
 MONGODB_EXPORTER_CONSUL_SERVICE:
   service:
     name: mongodb-exporter

--- a/playbooks/roles/mongodb/defaults/main.yml
+++ b/playbooks/roles/mongodb/defaults/main.yml
@@ -1,2 +1,15 @@
-MONGODB_OPENSTACK_DB_DEVICE: '/dev/vdb1'
-MONGODB_SERVER_BACKUP_DIR: '/var/lib/mongodb/backup'
+---
+MONGODB_OPENSTACK_DB_DEVICE: /dev/vdb1
+MONGODB_SERVER_BACKUP_DIR: /var/lib/mongodb/backup
+
+MONGODB_EXPORTER_ENABLED: true
+MONGODB_EXPORTER_DOWNLOAD_URL: https://github.com/dcu/mongodb_exporter/releases/download/v1.0.0/mongodb_exporter-linux-amd64
+MONGODB_EXPORTER_PASSWORD: null
+MONGODB_EXPORTER_CONSUL_SERVICE:
+  service:
+    name: mongodb-exporter
+    tags:
+      - mongodb-exporter
+      - monitor-https
+    port: 19001
+    enable_tag_override: true

--- a/playbooks/roles/mongodb/files/mongodb_exporter.service
+++ b/playbooks/roles/mongodb/files/mongodb_exporter.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Prometheus MongoDB Exporter
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/mongodb_exporter -web.listen-address 127.0.0.1:9001
+EnvironmentFile=/etc/mongodb_exporter.conf
+Restart=always
+RestartSec=10
+User=mongodb
+Group=mongodb
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/mongodb/meta/main.yml
+++ b/playbooks/roles/mongodb/meta/main.yml
@@ -1,0 +1,12 @@
+---
+dependencies:
+  - name: nginx-proxy
+    # The username is a bit misleading – should actually be "prometheus", since it's the server
+    # authenticating, and the same username is used for scraping other exporters, but it's not worth
+    # the hassle to change it.
+    NGINX_PROXY_USERNAME: node-exporter
+    NGINX_PROXY_PASSWORD: "{{ MONGODB_EXPORTER_PASSWORD }}"
+    NGINX_PROXY_AUTH_DOMAIN: Prometheus MongoDB Exporter
+    NGINX_PROXY_CONFIG_PATH: /etc/nginx/sites-available/mongodb-exporter
+    NGINX_PROXY_PUBLIC_PORT: 19001
+    NGINX_PROXY_INTERNAL_PORT: 9001

--- a/playbooks/roles/mongodb/tasks/main.yml
+++ b/playbooks/roles/mongodb/tasks/main.yml
@@ -1,11 +1,22 @@
+---
 - name: Create mongodb group
-  group: name=mongodb system=yes
+  group:
+    name: mongodb
+    system: yes
 
 - name: Create mongodb user
-  user: name=mongodb group=mongodb home=/var/lib/mongodb system=yes
+  user:
+    name: mongodb
+    group: mongodb
+    home: /var/lib/mongodb
+    system: yes
 
 - name: mount /var/lib/mongodb
-  mount: name=/var/lib/mongodb src="{{ MONGODB_OPENSTACK_DB_DEVICE }}" fstype=ext4 state=mounted
+  mount:
+    name: /var/lib/mongodb
+    src: "{{ MONGODB_OPENSTACK_DB_DEVICE }}"
+    fstype: ext4
+    state: mounted
 
 - name: mkdir /var/lib/mongodb/{db,log}
   file:
@@ -14,10 +25,17 @@
     mode: 0750
     owner: mongodb
     group: mongodb
-  with_items: ['db', 'log']
+  with_items:
+    - db
+    - log
 
 - name: chown -R /var/lib/mongodb
-  file: path=/var/lib/mongodb owner=mongodb group=mongodb recurse=yes state=directory
+  file:
+    path: /var/lib/mongodb
+    owner: mongodb
+    group: mongodb
+    recurse: yes
+    state: directory
 
 - name: chmod /var/lib/mongodb
   file:
@@ -26,9 +44,10 @@
     state: directory
 
 - name: Open MongoDB port on the firewall
-  ufw: rule=allow port={{ item }} proto=tcp
-  with_items:
-    - 27017
+  ufw:
+    rule: allow
+    port: 27017
+    proto: tcp
 
 - name: configure log rotation for the MongoDB log
   template:
@@ -40,14 +59,48 @@
   template:
     src: backup-pre-mongodb.sh
     dest: /usr/local/sbin/backup-pre.sh
-    owner: root
-    group: root
     mode: 0500
 
 - name: Copy post-backup script
   template:
     src: backup-post-mongodb.sh
     dest: /usr/local/sbin/backup-post.sh
-    owner: root
-    group: root
     mode: 0500
+
+- name: Install Prometheus MongoDB exporter
+  when: MONGODB_EXPORTER_ENABLED
+  block:
+
+    - name: Download MongoDB exporter
+      get_url:
+        url: "{{ MONGODB_EXPORTER_DOWNLOAD_URL }}"
+        dest: /usr/local/bin/mongodb_exporter
+        mode: 0755
+
+    - name: Create MongoDB exporter environment file
+      copy:
+        content: |
+          MONGODB_URL=mongodb://{{ mongodb_root_admin_name }}:{{ mongodb_root_admin_password }}@localhost:27017
+        dest: /etc/mongodb_exporter.conf
+        mode: 0640
+        owner: root
+        group: mongodb
+
+    - name: Copy MongoDB exporter service definition
+      copy:
+        src: mongodb_exporter.service
+        dest: /etc/systemd/system/mongodb_exporter.service
+
+    - name: Start MongoDB exporter
+      systemd:
+        daemon-reload: yes
+        name: mongodb_exporter.service
+        state: started
+        enabled: yes
+
+    - name: Create Consul service definition file
+      copy:
+        content: "{{ MONGODB_EXPORTER_CONSUL_SERVICE | to_nice_json }}"
+        dest: /etc/consul/mongodb-exporter.json
+      notify:
+        - reload consul

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -1,9 +1,41 @@
 ---
 
-# MYSQL_OPENSTACK_DB_DEVICE --- volume location e.g.: ``/dev/vdb1``
-MYSQL_OPENSTACK_DB_DEVICE: "/dev/vdb1"
+# GENERAL #####################################################################
 
-MYSQL_SERVER_BACKUP_DIR: '/var/lib/mysql/backup'
-
+MYSQL_OPENSTACK_DB_DEVICE: /dev/vdb1
+MYSQL_SERVER_BACKUP_DIR: /var/lib/mysql/backup
 MYSQL_OPEN_FILES_LIMIT: 65536
 MYSQL_PROCESSES_LIMIT: 1024
+
+# PROMETHEUS ##################################################################
+
+MYSQL_EXPORTER_ENABLED: true
+MYSQL_EXPORTER_VERSION: 0.10.0
+MYSQL_EXPORTER_BASENAME: "mysqld_exporter-{{ MYSQL_EXPORTER_VERSION }}.linux-amd64"
+MYSQL_EXPORTER_BINARY: "/opt/{{ MYSQL_EXPORTER_BASENAME }}/mysqld_exporter"
+MYSQL_EXPORTER_ARCHIVE: "{{ MYSQL_EXPORTER_BASENAME }}.tar.gz"
+MYSQL_EXPORTER_DOWNLOAD_URL: "https://github.com/prometheus/mysqld_exporter/releases/download/v{{ MYSQL_EXPORTER_VERSION }}/{{ MYSQL_EXPORTER_ARCHIVE }}"
+MYSQL_EXPORTER_PASSWORD: null
+MYSQL_EXPORTER_MYSQL_PASSWORD: null
+
+# We use this by default because when you have a little too many databases,
+# the exporter takes ~40-50min to enter a listening state, and always times
+# out through the reverse proxy to actually retrieve these metrics.
+# It is uncertain whether this can actually be fixed in the exporter -- it
+# may just be a limitation of having too many databases in MySQL.
+MYSQL_EXPORTER_EXTRA_OPTS: "-collect.info_schema.tables=false"
+
+MYSQL_EXPORTER_MYSQL_USERS:
+  - name: exporter
+    host: "%"
+    password: "{{ MYSQL_EXPORTER_MYSQL_PASSWORD }}"
+    priv: "*.*:PROCESS,REPLICATION CLIENT,SELECT"
+
+MYSQL_EXPORTER_CONSUL_SERVICE:
+  service:
+    name: mysqld-exporter
+    tags:
+      - mysqld-exporter
+      - monitor-https
+    port: 19104
+    enable_tag_override: true

--- a/playbooks/roles/mysql/meta/main.yml
+++ b/playbooks/roles/mysql/meta/main.yml
@@ -2,13 +2,13 @@
 
 dependencies:
   - name: nginx-proxy
-    when: MONGODB_EXPORTER_ENABLED
+    when: MYSQL_EXPORTER_ENABLED
     # The username is a bit misleading – should actually be "prometheus", since it's the server
     # authenticating, and the same username is used for scraping other exporters, but it's not worth
     # the hassle to change it.
     NGINX_PROXY_USERNAME: node-exporter
-    NGINX_PROXY_PASSWORD: "{{ MONGODB_EXPORTER_PASSWORD }}"
-    NGINX_PROXY_AUTH_DOMAIN: Prometheus MongoDB Exporter
-    NGINX_PROXY_CONFIG_PATH: /etc/nginx/sites-available/mongodb-exporter
-    NGINX_PROXY_PUBLIC_PORT: 19001
-    NGINX_PROXY_INTERNAL_PORT: 9001
+    NGINX_PROXY_PASSWORD: "{{ MYSQL_EXPORTER_PASSWORD }}"
+    NGINX_PROXY_AUTH_DOMAIN: Prometheus MySQL Exporter
+    NGINX_PROXY_CONFIG_PATH: /etc/nginx/sites-available/mysql-exporter
+    NGINX_PROXY_PUBLIC_PORT: 19104
+    NGINX_PROXY_INTERNAL_PORT: 9104

--- a/playbooks/roles/mysql/tasks/main.yml
+++ b/playbooks/roles/mysql/tasks/main.yml
@@ -1,17 +1,35 @@
+---
+
 # edX is currently using MySQL 5.6, which is not available on Xenial by default.
 - name: Add PPA for MySQL 5.6
   apt_repository:
     repo: "ppa:ondrej/mysql-5.6"
     update_cache: yes
 
+# This task can be removed once we move to the latest version of the geerlingguy.mysql role.  The
+# version we are currently using only installs the Python2 version of python-mysqldb.
+- name: Install python3-mysqldb package
+  apt:
+    name: python3-mysqldb
+
 - name: Create mysql group
-  group: name=mysql system=yes
+  group:
+    name: mysql
+    system: yes
 
 - name: Create mysql user
-  user: name=mysql group=mysql system=yes
+  user:
+    name: mysql
+    group: mysql
+    system: yes
 
 - name: chown -R /var/lib/mysql
-  file: path=/var/lib/mysql owner=mysql group=mysql recurse=yes state=directory
+  file:
+    path: /var/lib/mysql
+    owner: mysql
+    group: mysql
+    recurse: yes
+    state: directory
 
 - name: chmod /var/lib/mysql
   file:
@@ -20,28 +38,23 @@
     state: directory
 
 - name: Allow required ports
-  ufw: rule=allow port={{ item }} proto=tcp
-  with_items:
-    - 3306
-#
+  ufw:
+    rule: allow
+    port: 3306
+    proto: tcp
+
 # Parameters to set the maximum number of open files
-#
 - name: Creating directory for Mysql files limit configuration
   file:
     path: /etc/systemd/system/mysql.service.d/
     state: directory
     mode: 0755
-    owner: root
-    group: root
 
-# 
 # The limits of processes started by systemd are governed by systemd configuration
 # files and not from security/limits.d
 - name: Set open files limit in mysql through systemd
   copy:
     dest: /etc/systemd/system/mysql.service.d/override.conf
-    owner: root
-    group: root
     content: |
       # cf https://duntuk.com/how-raise-ulimit-open-files-and-mysql-openfileslimit
       [Service]
@@ -52,14 +65,55 @@
   template:
     src: backup-pre-mysql.sh
     dest: /usr/local/sbin/backup-pre.sh
-    owner: root
-    group: root
     mode: 0500
 
 - name: Copy post-backup script
   template:
     src: backup-post-mysql.sh
     dest: /usr/local/sbin/backup-post.sh
-    owner: root
-    group: root
     mode: 0500
+
+- name: Install Prometheus MySQL exporter
+  when: MYSQL_EXPORTER_ENABLED
+  block:
+
+    - name: Download MySQL exporter
+      unarchive:
+        src: "{{ MYSQL_EXPORTER_DOWNLOAD_URL }}"
+        remote_src: yes
+        dest: /opt
+        creates: "{{ MYSQL_EXPORTER_BINARY }}"
+
+    - name: Append MySQL exporter user to list of MySQL users
+      # Note that the database will only be installed later, so we need to rely on the
+      # external role to create the users.
+      set_fact:
+        mysql_users: "{{ mysql_users + MYSQL_EXPORTER_MYSQL_USERS }}"
+
+    - name: Create MySQL exporter environment file
+      copy:
+        content: |
+          DATA_SOURCE_NAME='exporter:{{ MYSQL_EXPORTER_MYSQL_PASSWORD }}@(localhost:3306)/'
+        dest: /etc/mysqld_exporter.conf
+        mode: 0640
+        owner: root
+        group: mysql
+
+    - name: Copy MySQL exporter service definition
+      template:
+        src: mysqld_exporter.service.j2
+        dest: /etc/systemd/system/mysqld_exporter.service
+
+    - name: Start MySQL exporter
+      systemd:
+        daemon-reload: yes
+        name: mysqld_exporter.service
+        state: started
+        enabled: yes
+
+    - name: Create Consul service definition file
+      copy:
+        content: "{{ MYSQL_EXPORTER_CONSUL_SERVICE | to_nice_json }}"
+        dest: /etc/consul/mysqld-exporter.json
+      notify:
+        - reload consul

--- a/playbooks/roles/mysql/templates/mysqld_exporter.service.j2
+++ b/playbooks/roles/mysql/templates/mysqld_exporter.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Prometheus MySQL Exporter
+After=network-online.target
+
+[Service]
+ExecStart={{ MYSQL_EXPORTER_BINARY }} -web.listen-address 127.0.0.1:9104 {% if MYSQL_EXPORTER_EXTRA_OPTS != "" %}{{ MYSQL_EXPORTER_EXTRA_OPTS }}{% endif %}
+EnvironmentFile=/etc/mysqld_exporter.conf
+Restart=always
+RestartSec=10
+User=mysql
+Group=mysql
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Test instructions:

1. Go to https://prometheus.net.opencraft.hosting/targets. The default username is 'prometheus' and you should have the password.
2. Ensure that the HAProxy, MongoDB, and MySQL exporters show as being healthy targets (not red). (Note: you will see one of the HAProxy ones, haproxy-stage.opencraft.hosting, being red for reasons discussed on the ticket).
3. Go to https://haproxy-stage-3.net.opencraft.hosting:19101/metrics, https://mongodb-stage.opencraft.hosting:19001/metrics, and https://mysql-im-2-slave2.net.opencraft.hosting:19104/metrics. The default username is 'node-exporter' and you should have the password. Let your browser skip verifying the SSL certificate -- it's not provided by a recognized certificate authority.
4. For each of the above, ensure that you see a ton of variables somewhere that seem related to the particular service.
5. Go to https://prometheus.net.opencraft.hosting:3443/dashboards and login with credentials provided to you.
6. For each of MySQL, MongoDB, and HAProxy that you see on the list, open them up in new tabs. Take a look at each, and ensure the graphs are working (the data provided is literally the data seen from steps 3/4).