### PR TITLE
Fix logging and backup logs for LPD.

### DIFF
--- a/playbooks/group_vars/learner-profile-dashboard/public.yml
+++ b/playbooks/group_vars/learner-profile-dashboard/public.yml
@@ -38,10 +38,6 @@ SANITY_CHECK_LIVE_PORTS:
 
 SANITY_CHECK_SUBJECT: '[LPD] Sanity check problems'
 
-SANITY_CHECK_COMMANDS:
-  - command: "{{ LPD_MANAGE_PY }} sanity_check"
-    message: "Sanity check failed for LPD. Is database accessible?"
-
 # FILEBEAT ####################################################################
 
 filebeat_prospectors:

--- a/playbooks/roles/learner-profile-dashboard/templates/lpd-pre-backup.sh
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd-pre-backup.sh
@@ -7,9 +7,9 @@ service gunicorn restart
 timestamp=$(date +%Y%m%dT%H:%M:%S)
 
 mv /var/log/lpd/debug.log-* "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}"
-chown "{{ LPD_LOG_DOWNLOAD_USER }}:{{ LPD_DB_USERNAME }}" "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}" "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"
+chown "{{ LPD_LOG_DOWNLOAD_USER }}:{{ LPD_USER_NAME }}" "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}" "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"
 chmod g+rwx "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}" "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"
-sudo -u "{{ LPD_DB_USERNAME }}" -H {{LPD_MANAGE_PY}} dumpdata -o "{{ LPD_LOG_DOWNLOAD_DB_DIR }}/database-${timestamp}.json"
+sudo -u "{{ LPD_USER_NAME }}" -H {{LPD_MANAGE_PY}} dumpdata -o "{{ LPD_LOG_DOWNLOAD_DB_DIR }}/database-${timestamp}.json"
 mysqldump -u "{{ LPD_DB_USERNAME }}" -p'{{ LPD_DB_PASSWORD }}' -h "{{ LPD_DB_HOST }}" "{{ LPD_DB_NAME }}" -r "{{ LPD_LOG_DOWNLOAD_DB_DIR }}/database-${timestamp}.sql"
 gzip "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}"/* "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"/*
 chown "{{ LPD_LOG_DOWNLOAD_USER }}:{{ LPD_LOG_DOWNLOAD_USER }}" "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}"/* "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"/*

--- a/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
@@ -28,43 +28,43 @@ DATABASES = {
 if getpass.getuser() == '{{ LPD_USER_NAME }}':
     # Change log paths only for production requests
     LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'file_debug_log': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': '{{ LPD_LOG_DIR }}/debug.log',
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'file_debug_log': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': '{{ LPD_LOG_DIR }}/debug.log',
+            },
+            'file_test_log': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': '{{ LPD_LOG_DIR }}/test.log',
+            },
         },
-        'file_test_log': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': '{{ LPD_LOG_DIR }}/test.log',
+        'loggers': {
+            'django.request': {
+                'handlers': ['file_debug_log'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
+            'django_lti_tool_provider.views': {
+                'handlers': ['file_debug_log'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
+            'lpd.views': {
+                'handlers': ['file_debug_log'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
+            'lpd.tests': {
+                'handlers': ['file_test_log'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
         },
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['file_debug_log'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-        'django_lti_tool_provider.views': {
-            'handlers': ['file_debug_log'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-        'lpd.views': {
-            'handlers': ['file_debug_log'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-        'lpd.tests': {
-            'handlers': ['file_test_log'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-    },
-}
+    }
 
 STATIC_ROOT="{{ LPD_STATICFILES_ROOT }}"
 STATIC_URL="/static/"


### PR DESCRIPTION
This PR fixes `lpd-pre-backup.sh` file to enable backups of app logs. It also enhances logs with timestamps and removes single sanity check which called a non-existant file.

The code of this playbook has been used to deploy LPD production.

Squashed from https://github.com/open-craft/ansible-playbooks/commit/140a7482b71534c5eb211a1cb078b0d3f538d236.
Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>