### PR TITLE
Increment tarsnap version to 1.0.39

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/kamaln7/ansible-swapfile
 [submodule "playbooks/roles/pmbauer.tarsnap"]
 	path = playbooks/roles/pmbauer.tarsnap
-	url = https://github.com/pmbauer/ansible-tarsnap
+	url = https://github.com/open-craft/ansible-tarsnap
 [submodule "playbooks/roles/geerlingguy.mysql"]
 	path = playbooks/roles/geerlingguy.mysql
 	url = https://github.com/open-craft/ansible-role-mysql

--- a/playbooks/group_vars/all/public.yml
+++ b/playbooks/group_vars/all/public.yml
@@ -6,7 +6,7 @@ ansible_python_interpreter: /usr/bin/python3
 
 # TARSNAP #####################################################################
 
-tarsnap_version: 1.0.37
+tarsnap_version: 1.0.39
 tarsnap_cache: /var/tarsnap/cache
 tarsnap_cron_hour: "*"
 


### PR DESCRIPTION
This updates Tarsnap to the newest version (1.0.39) as of May 29th, 2018.
I've tested and deployed this on our production and staging servers, and we should use this on new servers going forward.