### PR TITLE
Fix failing pre-backup script for LPD.

### DIFF
--- a/playbooks/learner-profile-dashboard.yml
+++ b/playbooks/learner-profile-dashboard.yml
@@ -19,6 +19,10 @@
       # Backup of logs is initiated by logrotate, which incidentally
       # also creates data to be backed up.
       TARSNAP_CRONTAB_STATE: "absent"
+
+      # The backup lock is causing problems for LPD, since the lock is inherited by
+      # gunicorn workers, which don't release it unless they are stopped.  Since the lock
+      # is not needed for a daily backup anyway, we simply disable it.
       TARSNAP_BACKUP_GLOBAL_LOCK: false
 
     - role: learner-profile-dashboard

--- a/playbooks/learner-profile-dashboard.yml
+++ b/playbooks/learner-profile-dashboard.yml
@@ -19,6 +19,7 @@
       # Backup of logs is initiated by logrotate, which incidentally
       # also creates data to be backed up.
       TARSNAP_CRONTAB_STATE: "absent"
+      TARSNAP_BACKUP_GLOBAL_LOCK: false
 
     - role: learner-profile-dashboard
       tags: 'learner-profile-dashboard'

--- a/playbooks/roles/dalite/templates/dalite-pre-backup.sh
+++ b/playbooks/roles/dalite/templates/dalite-pre-backup.sh
@@ -6,7 +6,9 @@ service gunicorn restart
 
 timestamp=$(date +%Y%m%dT%H:%M:%S)
 
-mv /var/log/dalite/student.log-* "{{ DALITE_LOG_DOWNLOAD_LOG_DIR }}"
+if [ -f /var/log/dalite/student.log-* ]; then
+   mv /var/log/dalite/student.log-* "{{ DALITE_LOG_DOWNLOAD_LOG_DIR }}"
+fi
 chown "{{ DALITE_LOG_DOWNLOAD_USER }}:{{ MYSQL_DALITE_USER }}" "{{ DALITE_LOG_DOWNLOAD_LOG_DIR }}" "{{ DALITE_LOG_DOWNLOAD_DB_DIR }}"
 chmod g+rwx "{{ DALITE_LOG_DOWNLOAD_LOG_DIR }}" "{{ DALITE_LOG_DOWNLOAD_DB_DIR }}"
 sudo -u "{{ MYSQL_DALITE_USER }}" -H {{DALITE_MANAGE_PY}} dumpdata -o "{{ DALITE_LOG_DOWNLOAD_DB_DIR }}/database-${timestamp}.json"

--- a/playbooks/roles/learner-profile-dashboard/templates/lpd-pre-backup.sh
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd-pre-backup.sh
@@ -6,7 +6,9 @@ service gunicorn restart
 
 timestamp=$(date +%Y%m%dT%H:%M:%S)
 
-mv /var/log/lpd/debug.log-* "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}"
+if [ -f /var/log/lpd/debug.log-* ]; then
+   mv /var/log/lpd/debug.log-* "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}"
+fi
 chown "{{ LPD_LOG_DOWNLOAD_USER }}:{{ LPD_USER_NAME }}" "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}" "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"
 chmod g+rwx "{{ LPD_LOG_DOWNLOAD_LOG_DIR }}" "{{ LPD_LOG_DOWNLOAD_DB_DIR }}"
 sudo -u "{{ LPD_USER_NAME }}" -H {{LPD_MANAGE_PY}} dumpdata -o "{{ LPD_LOG_DOWNLOAD_DB_DIR }}/database-${timestamp}.json"


### PR DESCRIPTION
This PR fixes failing `lpd-pre-backup.sh` script.
Changes have been already applied to LPD stage and production.

cf. [OC-4365](https://tasks.opencraft.com/browse/OC-4365)

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>