### PR TITLE
Add timestamps to logging in Learner Profile Dashboard app

### DIFF
--- a/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
@@ -30,11 +30,17 @@ if getpass.getuser() == '{{ LPD_USER_NAME }}':
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
+        'formatters': {
+            'timestamped': {
+                'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+            },
+        },
         'handlers': {
             'file_debug_log': {
                 'level': 'DEBUG',
                 'class': 'logging.FileHandler',
                 'filename': '{{ LPD_LOG_DIR }}/debug.log',
+                'formatter': 'timestamped',
             },
             'file_test_log': {
                 'level': 'DEBUG',


### PR DESCRIPTION
This PR adds timestamps to logging in LPD. It had been introduced via https://github.com/open-craft/ansible-playbooks/commit/d103ef658097f92d3b911aaff6b51d0e5f09526e but then was accidentally removed in https://github.com/open-craft/ansible-playbooks/pull/39.

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>