### PR TITLE
Fix issues with the MySQL exporter.

### DIFF
--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -16,7 +16,6 @@ MYSQL_EXPORTER_BINARY: "/opt/{{ MYSQL_EXPORTER_BASENAME }}/mysqld_exporter"
 MYSQL_EXPORTER_ARCHIVE: "{{ MYSQL_EXPORTER_BASENAME }}.tar.gz"
 MYSQL_EXPORTER_DOWNLOAD_URL: "https://github.com/prometheus/mysqld_exporter/releases/download/v{{ MYSQL_EXPORTER_VERSION }}/{{ MYSQL_EXPORTER_ARCHIVE }}"
 MYSQL_EXPORTER_PASSWORD: null
-MYSQL_EXPORTER_MYSQL_PASSWORD: null
 
 # We use this by default because when you have a little too many databases,
 # the exporter takes ~40-50min to enter a listening state, and always times
@@ -25,9 +24,10 @@ MYSQL_EXPORTER_MYSQL_PASSWORD: null
 # may just be a limitation of having too many databases in MySQL.
 MYSQL_EXPORTER_EXTRA_OPTS: "-collect.info_schema.tables=false"
 
+MYSQL_EXPORTER_MYSQL_PASSWORD: null
 MYSQL_EXPORTER_MYSQL_USERS:
   - name: exporter
-    host: "%"
+    host: "127.0.0.1"
     password: "{{ MYSQL_EXPORTER_MYSQL_PASSWORD }}"
     priv: "*.*:PROCESS,REPLICATION CLIENT,SELECT"
 

--- a/playbooks/roles/mysql/handlers/main.yml
+++ b/playbooks/roles/mysql/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: restart mysqld_exporter
+  service:
+    name: mysqld_exporter
+    state: restarted

--- a/playbooks/roles/mysql/tasks/main.yml
+++ b/playbooks/roles/mysql/tasks/main.yml
@@ -83,6 +83,7 @@
         remote_src: yes
         dest: /opt
         creates: "{{ MYSQL_EXPORTER_BINARY }}"
+      notify: restart mysqld_exporter
 
     - name: Append MySQL exporter user to list of MySQL users
       # Note that the database will only be installed later, so we need to rely on the
@@ -98,11 +99,13 @@
         mode: 0640
         owner: root
         group: mysql
+      notify: restart mysqld_exporter
 
     - name: Copy MySQL exporter service definition
       template:
         src: mysqld_exporter.service.j2
         dest: /etc/systemd/system/mysqld_exporter.service
+      notify: restart mysqld_exporter
 
     - name: Start MySQL exporter
       systemd:

--- a/playbooks/roles/mysql/templates/mysqld_exporter.service.j2
+++ b/playbooks/roles/mysql/templates/mysqld_exporter.service.j2
@@ -3,7 +3,7 @@ Description=Prometheus MySQL Exporter
 After=network-online.target
 
 [Service]
-ExecStart={{ MYSQL_EXPORTER_BINARY }} -web.listen-address 127.0.0.1:9104 {% if MYSQL_EXPORTER_EXTRA_OPTS != "" %}{{ MYSQL_EXPORTER_EXTRA_OPTS }}{% endif %}
+ExecStart={{ MYSQL_EXPORTER_BINARY }} {% if MYSQL_EXPORTER_EXTRA_OPTS != "" %}{{ MYSQL_EXPORTER_EXTRA_OPTS }}{% endif %} -web.listen-address 127.0.0.1:9104
 EnvironmentFile=/etc/mysqld_exporter.conf
 Restart=always
 RestartSec=10


### PR DESCRIPTION
* Should notify for a restart on the service.
* Should use 127.0.0.1 so we can include password in group vars safely.
* For some reason the template seems to not print a newline if
  end with {% endif %}.

Does not need review: makes no functional change, and only matches what is currently live.