### PR TITLE
Update logging configuration for LPD.

### DIFF
--- a/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
@@ -64,6 +64,11 @@ if getpass.getuser() == '{{ LPD_USER_NAME }}':
                 'level': 'DEBUG',
                 'propagate': True,
             },
+            'lpd.client': {
+                'handlers': ['file_debug_log'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
             'lpd.tests': {
                 'handlers': ['file_test_log'],
                 'level': 'DEBUG',


### PR DESCRIPTION
cf. [OC-4751](https://tasks.opencraft.com/browse/OC-4751)

**Related PRs**

- https://github.com/open-craft/learner-profile-dashboard/pull/15
- https://github.com/open-craft/ansible-secrets/pull/58

**Test instructions**

None. This just enables logging for an additional module ([`lpd/client.py`](https://github.com/open-craft/learner-profile-dashboard/blob/master/lpd/client.py)). We previously verified that the playbook puts `templates/lpd_settings.py` in the right place, and that the LPD applies any custom settings that it contains (cf. https://github.com/open-craft/ansible-secrets/pull/54).

**Reviewers**

- [x] @tomaszgy 