### PR TITLE
Make a curator action file and ignore kibana index.

### DIFF
--- a/playbooks/roles/curator/defaults/main.yml
+++ b/playbooks/roles/curator/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 
+curator_config_dir: /etc/curator
+
+curator_elasticsearch_hosts:
+  - 127.0.0.1
+curator_elasticsearch_port: 9200
+
 curator_delete_indices_days: 5

--- a/playbooks/roles/curator/tasks/main.yml
+++ b/playbooks/roles/curator/tasks/main.yml
@@ -12,10 +12,22 @@
   apt:
     name: elasticsearch-curator
 
-# If this job needs to expand more than this, please move it to an action file.
-# https://www.elastic.co/guide/en/elasticsearch/client/curator/current/actionfile.html
-- name: Install Curator deletion cron job
+- name: Create curator config directory
+  file:
+    path: "{{ curator_config_dir }}"
+    state: directory
+    mode: 0750
+
+- name: Install Curator configuration files
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ curator_config_dir }}/{{ item }}"
+  with_items:
+    - action.yml
+    - config.yml
+
+- name: Install Curator cron job
   cron:
     name: "Delete indices older than {{ curator_delete_indices_days }} days"
-    job: "curator_cli delete_indices --filter_list '[{ \"filtertype\": \"age\", \"source\": \"creation_date\", \"direction\": \"older\", \"unit\": \"days\", \"unit_count\": {{ curator_delete_indices_days }} }]'"
+    job: "curator --config {{ curator_config_dir }}/config.yml {{ curator_config_dir }}/action.yml"
     special_time: daily

--- a/playbooks/roles/curator/templates/action.yml.j2
+++ b/playbooks/roles/curator/templates/action.yml.j2
@@ -1,0 +1,13 @@
+---
+actions:
+  1:
+    action: delete_indices
+    description: "Delete indices older than {{ curator_delete_indices_days }} days."
+    filters:
+      - filtertype: kibana
+        exclude: true
+      - filtertype: age
+        source: creation_date
+        direction: older
+        unit: days
+        unit_count: {{ curator_delete_indices_days }}

--- a/playbooks/roles/curator/templates/config.yml.j2
+++ b/playbooks/roles/curator/templates/config.yml.j2
@@ -1,0 +1,4 @@
+---
+client:
+  hosts: {{ curator_elasticsearch_hosts }}
+  port: {{ curator_elasticsearch_port }}


### PR DESCRIPTION
The old cronjob was deleting the Kibana index too because the Kibana index became older than X amount of days. We don't want that, so I created a proper action file now to do the same deletion as before but this time also ignore the Kibana index.

*Test Instructions*:

1. Run `curator_cli show_indices` to see current indices.
1. Change the number of days in `/etc/curator/action.yml` to 2.
1. Run the command `curator --config /etc/curator/config.yml /etc/curator/action.yml` as root manually.
1. Run `curator_cli show_indices` again and ensure only the proper indices are deleted, and Kibana is left intact.
1. **Change back the number of days to the current 5**.