### PR TITLE
Set mysql wait timeout to reasonable value

### DIFF
--- a/playbooks/group_vars/mysql/public.yml
+++ b/playbooks/group_vars/mysql/public.yml
@@ -6,6 +6,7 @@ MYSQL_SERVER_DOMAIN: "{{ inventory_hostname }}"
 MYSQL_SERVER_BACKUP_DIR: '/var/lib/mysql/backup'
 mysql_root_password_update: true
 mysql_table_open_cache: 200000
+mysql_wait_timeout: 300
 mysql_skip_name_resolve: true
 mysql_packages:
   - mysql-server-5.5


### PR DESCRIPTION
This sets the [`wait_timeout`](https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_wait_timeout) for MySQL servers to 5 minutes, rather than the 8 hours set by default.

The previous setting held open unused MySQL connections for too long and risks exhausting the connection table on MySQL servers.