### PR TITLE
Install Redis and Memcache on Nomad clients.

### DIFF
--- a/playbooks/roles/nomad/tasks/main.yml
+++ b/playbooks/roles/nomad/tasks/main.yml
@@ -89,12 +89,32 @@
     - tcp
     - udp
 
-- name: Open port range on the firewall for Nomad task allocation
-  ufw:
-    rule: allow
-    port: '20000:32000'
-    proto: "{{ item }}"
-  with_items:
-    - tcp
-    - udp
+- name: Configure Nomad clients
   when: nomad_client
+  block:
+
+    - name: Open port range on the firewall for Nomad task allocation
+      ufw:
+        rule: allow
+        port: '20000:32000'
+        proto: "{{ item }}"
+      with_items:
+        - tcp
+        - udp
+
+    - name: Install Redis and Memcache on clients
+      apt:
+        name:
+          - memcached
+          - redis-sentinel
+          - redis-server
+
+    - name: Stop the Redis and Memcache processes started by the packages
+      systemd:
+        name: "{{ item }}"
+        enabled: false
+        state: stopped
+      with_items:
+        - memcached
+        - redis-sentinel
+        - redis-server

--- a/playbooks/roles/nomad/templates/nomad.service.j2
+++ b/playbooks/roles/nomad/templates/nomad.service.j2
@@ -4,7 +4,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-User=nomad
+User={{ "nomad" if nomad_server else "root" }}
 Group=nomad
 PermissionsStartOnly=true
 ExecStart={{ nomad_bin_dir }}/nomad agent -config={{ nomad_config_dir }}


### PR DESCRIPTION
We want to run Redis and Memcache on the Nomad cluster, and the easiest way to do so is to install them via apt, and then use the Nomad "exec" driver to spawn the processes.

This PR also makes sure that Nomad clients are run as root, which is required for them to be able to properly launch tasks.