### PR TITLE
Add a certbot hook to restart nginx on deploying renewed certificates

### DIFF
--- a/playbooks/roles/certbot/files/restart-nginx.sh
+++ b/playbooks/roles/certbot/files/restart-nginx.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl reload nginx.service

--- a/playbooks/roles/certbot/tasks/main.yml
+++ b/playbooks/roles/certbot/tasks/main.yml
@@ -43,6 +43,17 @@
     path: /var/www/certbot
     state: directory
 
+- name: Create Certbot deploy hooks directory
+  file:
+    path: /etc/letsencrypt/renewal-hooks/deploy
+    state: directory
+
+- name: Copy the Certbot deploy hook to restart nginx on renewal
+  copy:
+    src: restart-nginx.sh
+    dest: /etc/letsencrypt/renewal-hooks/deploy/restart-nginx.sh
+    mode: 0755
+
 - name: generate SSL certificate with certbot
   shell: >-
     certbot certonly


### PR DESCRIPTION
This PR adds a certbot hook script `restart-nginx.sh` (which reloads the nginx service) to the `/etc/letsencrypt/renewal-hooks/deploy` directory. Verified that nginx uses the renewed certificate by doing a forced renewal with the `--force-renewal` flag and checking the validity of the certificate presented by nginx on connecting to port 19100.