### PR TITLE
Upgrade Consul to version 1.2.1.

### DIFF
--- a/playbooks/roles/consul/defaults/main.yml
+++ b/playbooks/roles/consul/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-consul_version: 1.0.6
+consul_version: 1.2.1
 
 consul_ip: "{{ ansible_default_ipv4.address }}"
 consul_nodename: "{{ ansible_nodename }}"

--- a/playbooks/roles/consul/tasks/main.yml
+++ b/playbooks/roles/consul/tasks/main.yml
@@ -30,6 +30,11 @@
     - { path: "{{ consul_config_dir }}", owner: root }
     - { path: "{{ consul_data_dir }}", owner: consul }
 
+- name: Determine current Consul version
+  shell: consul version | sed -n 's/Consul v\(.*\)/\1/p'
+  register: consul_current_version
+  changed_when: false
+
 - name: Download and unarchive the Consul binary
   unarchive:
     src: "{{ consul_url }}"
@@ -37,7 +42,8 @@
     owner: consul
     group: consul
     remote_src: yes
-    creates: "{{ consul_bin_dir }}/consul"
+  when: consul_current_version.rc != 0 or consul_current_version.stdout != consul_version
+  notify: restart consul
 
 - name: Create Consul configuration file
   template:


### PR DESCRIPTION
This upgrades Consul to version 1.2.1, which is needed to use Consul Connect.

The code needed to be slightly modified to detect the currently running version of Consul, and reinstall and restart Consul in case a different version than requested is running.

All infrastructure servers in the production and stage clusters have already been upgraded.  I would like to merge this PR to make it easy to use the new Consul version on Ocim instances.