### PR TITLE
Add a missing backslash.

### DIFF
--- a/playbooks/roles/mattermail/defaults/main.yml
+++ b/playbooks/roles/mattermail/defaults/main.yml
@@ -16,4 +16,4 @@ MATTERMAIL_BRANCH: master
 MATTERMAIL_HOME: /opt/mattermail
 
 # Misc
-MATTERMAIL_MAIL_TEMPLATE: "@here :incoming_envelope: _From: **{{'{{'}}.From{{'}}'}}**_{{'\n'}}>_{{'{{'}}.Subject{{'}}'}}_"
+MATTERMAIL_MAIL_TEMPLATE: "@here :incoming_envelope: _From: **{{'{{'}}.From{{'}}'}}**_{{'\\n'}}>_{{'{{'}}.Subject{{'}}'}}_"


### PR DESCRIPTION
The mattermail config was incorrect without this. It is now fixed.