### PR TITLE
Add role to set up Consul Connect proxies on app servers.

### DIFF
--- a/playbooks/roles/appserver/README.md
+++ b/playbooks/roles/appserver/README.md
@@ -1,0 +1,11 @@
+Ocim appserver role
+===================
+
+This role is meant to run on Ocim app servers before the main Open edX playbook.  It currently sets
+up Consul Connect proxies for connecting to Redis and memcached.
+
+Role Variables
+--------------
+
+The only required variable is `ansible_instance_id`, which is used to derive the Consul service
+names to connect to.

--- a/playbooks/roles/appserver/defaults/main.yml
+++ b/playbooks/roles/appserver/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+appserver_instance_id: null
+
+# The local ports that will be tunnelled to memcached and redis-sentinel.
+appserver_memcached_ports:
+  - 11211
+  - 11212
+  - 11213
+appserver_redis_sentinel_ports:
+  - 6379
+  - 6380
+  - 6381
+
+# Build upstream specs for the Consul Connect command linde.
+appserver_memcached_upstream_specs: |-
+  {% for port in appserver_memcached_ports %} -upstream memcached-{{ appserver_instance_id }}-{{ loop.index0 }}:{{ port }}{% endfor %}
+appserver_redis_sentinel_upstream_specs: |-
+  {% for port in appserver_redis_sentinel_ports %} -upstream redis-sentinel-{{ appserver_instance_id }}-{{ loop.index0 }}:{{ port }}{% endfor %}

--- a/playbooks/roles/appserver/defaults/main.yml
+++ b/playbooks/roles/appserver/defaults/main.yml
@@ -11,7 +11,7 @@ appserver_redis_sentinel_ports:
   - 6380
   - 6381
 
-# Build upstream specs for the Consul Connect command linde.
+# Build upstream specs for the Consul Connect command line.
 appserver_memcached_upstream_specs: |-
   {% for port in appserver_memcached_ports %} -upstream memcached-{{ appserver_instance_id }}-{{ loop.index0 }}:{{ port }}{% endfor %}
 appserver_redis_sentinel_upstream_specs: |-

--- a/playbooks/roles/appserver/tasks/main.yml
+++ b/playbooks/roles/appserver/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Set up Consul Connect proxy endpoints for memcached and Redis Sentinel
+  template:
+    src: consul-connect.service.j2
+    dest: /etc/systemd/system/consul-connect.service
+  vars:
+    upstream_specs: "{{ appserver_memcached_upstream_specs }}{{ appserver_redis_sentinel_upstream_specs }}"
+
+- name: Start and enable the Consul Connect proxy
+  systemd:
+    name: consul-connect.service
+    enabled: true
+    state: started

--- a/playbooks/roles/appserver/templates/consul-connect.service.j2
+++ b/playbooks/roles/appserver/templates/consul-connect.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Mattermost
+Description=Consul Connect proxy
 After=network-online.target
 
 [Service]

--- a/playbooks/roles/appserver/templates/consul-connect.service.j2
+++ b/playbooks/roles/appserver/templates/consul-connect.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mattermost
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/consul connect proxy -service connect-proxy{{ upstream_specs }}
+Restart=always
+RestartSec=10
+User=consul
+Group=consul
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/consul/templates/config.json.j2
+++ b/playbooks/roles/consul/templates/config.json.j2
@@ -12,6 +12,9 @@
     "enable_syslog": {{ "true" if consul_enable_syslog else "false" }},
 {% if consul_server %}
     "bootstrap_expect": {{ consul_servers | length }},
+    "connect": {
+        "enabled": true
+    },
 {% endif %}
 {% if consul_encrypt != "" %}
     "encrypt": "{{ consul_encrypt }}",


### PR DESCRIPTION
This new role sets up the Consul Connect proxies required to connect to Redis and Memcache on Open edX app servers.  It is meant to be called by Ocim before running the `edx_sandbox.yml` playbook to actually set up Open edX.

For testing instructions, see https://tasks.opencraft.com/browse/OC-4333.
