### PR TITLE
Use the git hash rather than the full dictionary.

### DIFF
--- a/playbooks/roles/mattermail/tasks/main.yml
+++ b/playbooks/roles/mattermail/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: store git hash
   copy:
     dest: "{{ MATTERMAIL_HOME }}/.hash"
-    content: "{{ githash }}"
+    content: "{{ githash.after }}"
     owner: mattermail
     group: mattermail
   register: mattermail_version


### PR DESCRIPTION
When running the Mattermail role I noticed it always rebuilds the binary. This is because the `githash` value that we register is actually an entire dictionary, where the key/value pairs are not ordered, occasionally causing `githash` to then differ with what is inside of `/opt/mattermail/.hash` due to different order.

According to the [return values of the git module](https://docs.ansible.com/ansible/latest/modules/git_module.html#return-values), we want the `after` value. I used this diff to ensure that it doesn't re-install anymore if using the same commit hash -- and indeed it works out.