### PR TITLE
Connect to non-replicated Redis deployment without Sentinel.

### DIFF
--- a/playbooks/roles/appserver/defaults/main.yml
+++ b/playbooks/roles/appserver/defaults/main.yml
@@ -11,4 +11,4 @@ appserver_redis_port: 6379
 # Build upstream specs for the Consul Connect command line.
 appserver_memcached_upstream_specs: |-
   {% for port in appserver_memcached_ports %} -upstream memcached-{{ appserver_instance_id }}-{{ loop.index0 }}:{{ port }}{% endfor %}
-appserver_redis_upstream_specs: " -upstream redis-{{ appserver_instance_id }}-:{{ appserver_redis_port }}"
+appserver_redis_upstream_specs: " -upstream redis-{{ appserver_instance_id }}:{{ appserver_redis_port }}"

--- a/playbooks/roles/appserver/defaults/main.yml
+++ b/playbooks/roles/appserver/defaults/main.yml
@@ -1,18 +1,14 @@
 ---
 appserver_instance_id: null
 
-# The local ports that will be tunnelled to memcached and redis-sentinel.
+# The local ports that will be tunnelled to memcached and redis.
 appserver_memcached_ports:
   - 11211
   - 11212
   - 11213
-appserver_redis_sentinel_ports:
-  - 6379
-  - 6380
-  - 6381
+appserver_redis_port: 6379
 
 # Build upstream specs for the Consul Connect command line.
 appserver_memcached_upstream_specs: |-
   {% for port in appserver_memcached_ports %} -upstream memcached-{{ appserver_instance_id }}-{{ loop.index0 }}:{{ port }}{% endfor %}
-appserver_redis_sentinel_upstream_specs: |-
-  {% for port in appserver_redis_sentinel_ports %} -upstream redis-sentinel-{{ appserver_instance_id }}-{{ loop.index0 }}:{{ port }}{% endfor %}
+appserver_redis_upstream_specs: " -upstream redis-{{ appserver_instance_id }}-:{{ appserver_redis_port }}"

--- a/playbooks/roles/appserver/tasks/main.yml
+++ b/playbooks/roles/appserver/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: Set up Consul Connect proxy endpoints for memcached and Redis Sentinel
+- name: Set up Consul Connect proxy endpoints for memcached and Redis
   template:
     src: consul-connect.service.j2
     dest: /etc/systemd/system/consul-connect.service
   vars:
-    upstream_specs: "{{ appserver_memcached_upstream_specs }}{{ appserver_redis_sentinel_upstream_specs }}"
+    upstream_specs: "{{ appserver_memcached_upstream_specs }}{{ appserver_redis_upstream_specs }}"
 
 - name: Start and enable the Consul Connect proxy
   systemd:


### PR DESCRIPTION
Since we are not going to use a highly available Redis deployment in the first iteration, I needed to adapt this role for a single-process Redis deployment.  For testing, it's enough to run the role against some app server.  End-to-end testing will be performed as part of [OC-4334](https://tasks.opencraft.com/browse/OC-4334).