### PR TITLE
Prometheus exporters

### DIFF
--- a/playbooks/roles/mongodb/defaults/main.yml
+++ b/playbooks/roles/mongodb/defaults/main.yml
@@ -8,9 +8,14 @@ MONGODB_SERVER_BACKUP_DIR: /var/lib/mongodb/backup
 # PROMETHEUS ##################################################################
 
 MONGODB_EXPORTER_ENABLED: true
-MONGODB_EXPORTER_VERSION: 1.0.0
-MONGODB_EXPORTER_DOWNLOAD_URL: https://github.com/dcu/mongodb_exporter/releases/download/v{{ MONGODB_EXPORTER_VERSION }}/mongodb_exporter-linux-amd64
+MONGODB_EXPORTER_VERSION: 0.6.1
+MONGODB_EXPORTER_REPO: https://github.com/percona/mongodb_exporter.git
 MONGODB_EXPORTER_PASSWORD: null
+
+MONGODB_HOME: /var/lib/mongodb
+GO_PATH: "{{ MONGODB_HOME }}"
+MONGODB_EXPORTER_DIR: "github.com/percona/mongodb_exporter"
+MONGODB_EXPORTER_PATH: "{{ GO_PATH }}/src/{{ MONGODB_EXPORTER_DIR }}"
 
 MONGODB_EXPORTER_CONSUL_SERVICE:
   service:

--- a/playbooks/roles/mongodb/defaults/main.yml
+++ b/playbooks/roles/mongodb/defaults/main.yml
@@ -8,12 +8,13 @@ MONGODB_SERVER_BACKUP_DIR: /var/lib/mongodb/backup
 # PROMETHEUS ##################################################################
 
 MONGODB_EXPORTER_ENABLED: true
-MONGODB_EXPORTER_VERSION: 0.6.1
+MONGODB_EXPORTER_VERSION: "v0.6.2"
 MONGODB_EXPORTER_REPO: https://github.com/percona/mongodb_exporter.git
 MONGODB_EXPORTER_PASSWORD: null
 
+# This is not meant to be changed, but to improve the readability and to reduce the repetition
 MONGODB_HOME: /var/lib/mongodb
-GO_PATH: "{{ MONGODB_HOME }}"
+GO_PATH: "/tmp/mongodb"
 MONGODB_EXPORTER_DIR: "github.com/percona/mongodb_exporter"
 MONGODB_EXPORTER_PATH: "{{ GO_PATH }}/src/{{ MONGODB_EXPORTER_DIR }}"
 

--- a/playbooks/roles/mongodb/tasks/main.yml
+++ b/playbooks/roles/mongodb/tasks/main.yml
@@ -72,7 +72,7 @@
   block:
     - name: Create custom fact directory
       file:
-        path: "/etc/ansible/facts.d"
+        path: /etc/ansible/facts.d
         state: "directory"
 
     - name: Store MongoDB exporter version
@@ -82,8 +82,8 @@
         dest: /etc/ansible/facts.d/mongodb_exporter.fact
       register: mongodb_exporter_version
 
-    - name: Upgrade MongoDB exporter
-      when: mongodb_exporter_version.changed
+    - name: Install and Upgrade MongoDB exporter
+      when: ansible_local.mongodb_exporter is not defined or ansible_local.mongodb_exporter.version != MONGODB_EXPORTER_VERSION
       block:
         - name: Install golang package
           apt:
@@ -96,7 +96,6 @@
             repo: "{{ MONGODB_EXPORTER_REPO }}"
             dest: "{{ MONGODB_EXPORTER_PATH }}"
             version: "{{ MONGODB_EXPORTER_VERSION }}"
-          when: ansible_local.mongodb_exporter.version is version('MONGODB_EXPORTER_VERSION', '!=')
 
         - name: Compile MongoDB exporter files
           make:
@@ -111,6 +110,12 @@
             dest: /usr/local/bin/mongodb_exporter
             remote_src: yes
             mode: 0755
+
+        - name: Store MongoDB exporter version
+          copy:
+            content: |
+              {"version": "{{ MONGODB_EXPORTER_VERSION }}"}
+            dest: /etc/ansible/facts.d/mongodb_exporter.fact
 
     - name: Create MongoDB exporter environment file
       copy:

--- a/playbooks/roles/mongodb/tasks/main.yml
+++ b/playbooks/roles/mongodb/tasks/main.yml
@@ -75,13 +75,6 @@
         path: /etc/ansible/facts.d
         state: "directory"
 
-    - name: Store MongoDB exporter version
-      copy:
-        content: |
-          {"version": "{{ MONGODB_EXPORTER_VERSION }}"}
-        dest: /etc/ansible/facts.d/mongodb_exporter.fact
-      register: mongodb_exporter_version
-
     - name: Install and Upgrade MongoDB exporter
       when: ansible_local.mongodb_exporter is not defined or ansible_local.mongodb_exporter.version != MONGODB_EXPORTER_VERSION
       block:
@@ -111,12 +104,6 @@
             remote_src: yes
             mode: 0755
 
-        - name: Store MongoDB exporter version
-          copy:
-            content: |
-              {"version": "{{ MONGODB_EXPORTER_VERSION }}"}
-            dest: /etc/ansible/facts.d/mongodb_exporter.fact
-
     - name: Create MongoDB exporter environment file
       copy:
         content: |
@@ -137,6 +124,12 @@
         name: mongodb_exporter.service
         state: restarted
         enabled: yes
+
+    - name: Store MongoDB exporter version
+      copy:
+        content: |
+          {"version": "{{ MONGODB_EXPORTER_VERSION }}"}
+        dest: /etc/ansible/facts.d/mongodb_exporter.fact
 
     - name: Create Consul service definition file
       copy:

--- a/playbooks/roles/mongodb/tasks/main.yml
+++ b/playbooks/roles/mongodb/tasks/main.yml
@@ -8,19 +8,19 @@
   user:
     name: mongodb
     group: mongodb
-    home: /var/lib/mongodb
+    home: "{{ MONGODB_HOME }}"
     system: yes
 
-- name: mount /var/lib/mongodb
+- name: Mount MongoDB home
   mount:
-    name: /var/lib/mongodb
+    name: "{{ MONGODB_HOME }}"
     src: "{{ MONGODB_OPENSTACK_DB_DEVICE }}"
     fstype: ext4
     state: mounted
 
-- name: mkdir /var/lib/mongodb/{db,log}
+- name: Create db and log directories for MongoDB home
   file:
-    path: "/var/lib/mongodb/{{ item }}"
+    path: "{{ MONGODB_HOME }}/{{ item }}"
     state: directory
     mode: 0750
     owner: mongodb
@@ -29,17 +29,17 @@
     - db
     - log
 
-- name: chown -R /var/lib/mongodb
+- name: Change MongoDB Home owner
   file:
-    path: /var/lib/mongodb
+    path: "{{ MONGODB_HOME }}"
     owner: mongodb
     group: mongodb
     recurse: yes
     state: directory
 
-- name: chmod /var/lib/mongodb
+- name: Change MongoDB permissions
   file:
-    path: /var/lib/mongodb
+    path: "{{ MONGODB_HOME }}"
     mode: 0700
     state: directory
 
@@ -70,11 +70,33 @@
 - name: Install Prometheus MongoDB exporter
   when: MONGODB_EXPORTER_ENABLED
   block:
+    - name: Install golang package
+      apt:
+        name:
+          - golang
+        update_cache: yes
 
     - name: Download MongoDB exporter
-      get_url:
-        url: "{{ MONGODB_EXPORTER_DOWNLOAD_URL }}"
+      git:
+        repo: "{{ MONGODB_EXPORTER_REPO }}"
+        dest: "{{ MONGODB_EXPORTER_PATH }}"
+        version: "{{ MONGODB_EXPORTER_VERSION }}"
+
+    - name: Compile MongoDB exporter files
+      make:
+        chdir: "{{ MONGODB_EXPORTER_PATH }}"
+        target: build
+      environment:
+        GOPATH: "{{ GO_PATH }}"
+
+    - name: create symlink to exporter binary
+      file:
+        src: "{{ MONGODB_EXPORTER_PATH }}/mongodb_exporter"
         dest: /usr/local/bin/mongodb_exporter
+        state: link
+        force: yes
+        owner: mongodb
+        group: mongodb
         mode: 0755
 
     - name: Create MongoDB exporter environment file

--- a/playbooks/roles/mongodb/tasks/main.yml
+++ b/playbooks/roles/mongodb/tasks/main.yml
@@ -70,34 +70,47 @@
 - name: Install Prometheus MongoDB exporter
   when: MONGODB_EXPORTER_ENABLED
   block:
-    - name: Install golang package
-      apt:
-        name:
-          - golang
-        update_cache: yes
-
-    - name: Download MongoDB exporter
-      git:
-        repo: "{{ MONGODB_EXPORTER_REPO }}"
-        dest: "{{ MONGODB_EXPORTER_PATH }}"
-        version: "{{ MONGODB_EXPORTER_VERSION }}"
-
-    - name: Compile MongoDB exporter files
-      make:
-        chdir: "{{ MONGODB_EXPORTER_PATH }}"
-        target: build
-      environment:
-        GOPATH: "{{ GO_PATH }}"
-
-    - name: create symlink to exporter binary
+    - name: Create custom fact directory
       file:
-        src: "{{ MONGODB_EXPORTER_PATH }}/mongodb_exporter"
-        dest: /usr/local/bin/mongodb_exporter
-        state: link
-        force: yes
-        owner: mongodb
-        group: mongodb
-        mode: 0755
+        path: "/etc/ansible/facts.d"
+        state: "directory"
+
+    - name: Store MongoDB exporter version
+      copy:
+        content: |
+          {"version": "{{ MONGODB_EXPORTER_VERSION }}"}
+        dest: /etc/ansible/facts.d/mongodb_exporter.fact
+      register: mongodb_exporter_version
+
+    - name: Upgrade MongoDB exporter
+      when: mongodb_exporter_version.changed
+      block:
+        - name: Install golang package
+          apt:
+            name:
+              - golang
+            update_cache: yes
+
+        - name: Download MongoDB exporter
+          git:
+            repo: "{{ MONGODB_EXPORTER_REPO }}"
+            dest: "{{ MONGODB_EXPORTER_PATH }}"
+            version: "{{ MONGODB_EXPORTER_VERSION }}"
+          when: ansible_local.mongodb_exporter.version is version('MONGODB_EXPORTER_VERSION', '!=')
+
+        - name: Compile MongoDB exporter files
+          make:
+            chdir: "{{ MONGODB_EXPORTER_PATH }}"
+            target: build
+          environment:
+            GOPATH: "{{ GO_PATH }}"
+
+        - name: Add MongoDB exporter binary to the path
+          copy:
+            src: "{{ MONGODB_EXPORTER_PATH }}/mongodb_exporter"
+            dest: /usr/local/bin/mongodb_exporter
+            remote_src: yes
+            mode: 0755
 
     - name: Create MongoDB exporter environment file
       copy:
@@ -113,11 +126,11 @@
         src: mongodb_exporter.service
         dest: /etc/systemd/system/mongodb_exporter.service
 
-    - name: Start MongoDB exporter
+    - name: Start and enable MongoDB exporter
       systemd:
         daemon-reload: yes
         name: mongodb_exporter.service
-        state: started
+        state: restarted
         enabled: yes
 
     - name: Create Consul service definition file

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -22,7 +22,7 @@ MYSQL_EXPORTER_PASSWORD: null
 # out through the reverse proxy to actually retrieve these metrics.
 # It is uncertain whether this can actually be fixed in the exporter -- it
 # may just be a limitation of having too many databases in MySQL.
-MYSQL_EXPORTER_EXTRA_OPTS: "-collect.info_schema.tables=false"
+MYSQL_EXPORTER_EXTRA_OPTS: "-collect.info_schema.tables=false -collect.info_schema.query_response_time=true"
 
 MYSQL_EXPORTER_MYSQL_PASSWORD: null
 MYSQL_EXPORTER_MYSQL_USERS:


### PR DESCRIPTION
There're two changes this PR is introducing to help achieving [OC-5001](https://tasks.opencraft.com/browse/OC-5001) goals:
- Changing the MongoDB exporter to help us collecting MongoDB query execution time.
- Enable collecting mysql query response time by default.