### PR TITLE
[OC-5141] Invert logic in tarsnap role.

### DIFF
--- a/playbooks/roles/tarsnap/tasks/configure.yml
+++ b/playbooks/roles/tarsnap/tasks/configure.yml
@@ -1,8 +1,5 @@
 ---
 
-- fail: msg="Please specify tarsnap key"
-  when: "TARSNAP_KEY is not defined or TARSNAP_KEY == ''"
-
 - fail: msg="Please configure TARSNAP_BACKUP_FOLDERS, we want all servers to be backed up :)"
   when: "TARSNAP_BACKUP_FOLDERS is not defined or TARSNAP_BACKUP_FOLDERS == ''"
 

--- a/playbooks/roles/tarsnap/tasks/main.yml
+++ b/playbooks/roles/tarsnap/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 
 - include: install.yml
-  tags:
-    - tarsnap
+  tags: tarsnap
+
 - include: configure.yml
-  tags:
-    - tarsnap
   tarsnap_cache: "{{ TARSNAP_CACHE }}"
   tarsnap_keyfile: "{{ TARSNAP_KEY_REMOTE_LOCATION }}"
-  when: "TARSNAP_KEY is not defined or TARSNAP_KEY == ''"
+  when: "TARSNAP_KEY is defined and TARSNAP_KEY != ''"
+  tags: tarsnap


### PR DESCRIPTION
The current version is only configuring tarsnap when the tarsnap key isn't specified or is empty, which is the opposite of what it should be doing.