### PR TITLE
Various fixes for Mattermost and the autolinker.

### DIFF
--- a/playbooks/roles/mattermail/templates/mattermail.service.j2
+++ b/playbooks/roles/mattermail/templates/mattermail.service.j2
@@ -11,6 +11,9 @@ Restart=always
 RestartSec=10
 User=mattermail
 Group=mattermail
+# Mattermail seems to be leaking memory, so we let systemd kill it if it uses too much memory.
+MemoryHigh=120M
+MemoryMax=150M
 
 [Install]
 WantedBy=multi-user.target

--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -104,6 +104,13 @@
         url: "{{ MATTERMOST_UNLINK_DOWNLOAD_URL }}"
         dest: "{{ MATTERMOST_UNLINK_DOWNLOAD_DEST }}"
 
+    - name: create plugin directory
+      file:
+        path: "{{ MATTERMOST_INSTALL_DIR }}/mattermost/plugins"
+        state: directory
+        owner: mattermost
+        group: mattermost
+
     - name: unpack Mattermost autolink plugin
       unarchive:
         src: "{{ MATTERMOST_UNLINK_DOWNLOAD_DEST }}"

--- a/playbooks/roles/mattermost/templates/autolink.json.j2
+++ b/playbooks/roles/mattermost/templates/autolink.json.j2
@@ -6,12 +6,12 @@
 {% set domain_loop = loop %}
 {% for project in domain.projects %}
                     {
-                        "Pattern": "(?P<project>{{ project }})-(?P<id>\\d{1,6})",
-                        "Template": "[${project}-${id}](https://{{ domain.domain }}/browse/${project}-${id})"
+                        "Pattern": "(?P<project>{{ project }})-(?P<id>\\d{1,6})(?P<comma>[,;]*)",
+                        "Template": "[${project}-${id}](https://{{ domain.domain }}/browse/${project}-${id})${comma}"
                     },
                     {
-                        "Pattern": "https://{{ domain.domain }}/browse/(?P<project>{{ project }})-(?P<id>\\d{1,6})",
-                        "Template": "[${project}-${id}](https://{{ domain.domain }}/browse/${project}-${id})"
+                        "Pattern": "https://{{ domain.domain }}/browse/(?P<project>{{ project }})-(?P<id>\\d{1,6})(?P<query>\\?\\S*\\w)?",
+                        "Template": "[${project}-${id}](https://{{ domain.domain }}/browse/${project}-${id}${query})"
                     }{{ "," if not (loop.last and domain_loop.last) else "" }}
 {% endfor %}
 {% endfor %}

--- a/playbooks/roles/mattermost/templates/mattermost.service.j2
+++ b/playbooks/roles/mattermost/templates/mattermost.service.j2
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart={{ MATTERMOST_INSTALL_DIR }}/mattermost/bin/platform
+ExecStart={{ MATTERMOST_INSTALL_DIR }}/mattermost/bin/mattermost server
 Restart=always
 RestartSec=10
 WorkingDirectory={{ MATTERMOST_INSTALL_DIR }}/mattermost


### PR DESCRIPTION
This fixes a few issues with the Mattermost server:

* Mattermail will be killed if it uses too much memory, so it does not take Mattermost down.
* The Mattermost plugin directory is created if it does not exist yet.
* We now use the new `mattermost` binary instead of the deprecated `platform` binary.
* Correcly handle links with a query string in the autolinker.