### PR TITLE
Fix issue with backup pruner using too much memory at once.

### DIFF
--- a/playbooks/roles/backup-pruner/defaults/main.yml
+++ b/playbooks/roles/backup-pruner/defaults/main.yml
@@ -5,6 +5,15 @@ BACKUP_PRUNER_LOG_DIR: /var/log/backup-pruner
 BACKUP_PRUNER_SCRIPT: /usr/local/sbin/backup-pruner.sh
 BACKUP_PRUNER_SNITCH: null
 
+# Whether to ensure GNU Parallel only schedules jobs if swapping in and out is not taking place.
+BACKUP_PRUNER_JOB_NOSWAP: true
+# How many jobs to spawn at once. Making this number too high on a small server may spell issues.
+BACKUP_PRUNER_JOB_PARALLELISM: 2
+# How many times to retry a job if it fails.
+BACKUP_PRUNER_JOB_RETRIES: 3
+# The Linux nice value to give to processes kicked off by GNU Parallel.
+BACKUP_PRUNER_JOB_NICENESS: -20
+
 # Can be changed to normal tarsnapper once we merge this branch
 # and code winds up on PIP
 BACKUP_PRUNER_TARSNAPPER_VERSION: git+https://github.com/miracle2k/tarsnapper.git@0fedc22bcf8863fecb78c290a42dc28de96363b2

--- a/playbooks/roles/backup-pruner/templates/backup-pruner.sh
+++ b/playbooks/roles/backup-pruner/templates/backup-pruner.sh
@@ -19,7 +19,12 @@ task='output=$(/usr/local/sbin/tarsnap-{}.sh expire 2>&1 | tee -a {{ BACKUP_PRUN
 # Cron will send email if there is any stdout or stderr output regardless of the
 # response code, so by only including output for failed tasks in the output, an
 # email will only be sent out if and only if one or more backup pruners failed.
-echo "$jobs" | tail -n +2 | parallel --no-notice -j0 --joblog {{ BACKUP_PRUNER_JOB_LOG }} $task
+echo "$jobs" | tail -n +2 | parallel {% if BACKUP_PRUNER_JOB_NOSWAP %}--noswap{% endif %} \
+  --no-notice \
+  -j{{ BACKUP_PRUNER_JOB_PARALLELISM }} \
+  --retries {{ BACKUP_PRUNER_JOB_RETRIES }} \
+  --nice {{ BACKUP_PRUNER_JOB_NICENESS }} \
+  --joblog {{ BACKUP_PRUNER_JOB_LOG }} $task
 status=$?
 
 if [ $status -eq 0 ]


### PR DESCRIPTION
This is currently deployed.

Test instructions:

- Check jobs that happened after the start of this PR to ensure that the server did not have memory issues. You can probably use the fact that there are no missed data points as a proxy to determine whether this is working, because it means the node exporter process did not get killed by the kernel to free up memory.