### PR TITLE
Restrict common-apache2 to hxat-related servers

### DIFF
--- a/playbooks/hxat-catchpy-loris.yml
+++ b/playbooks/hxat-catchpy-loris.yml
@@ -2,7 +2,7 @@
 ## This playbook deploys hxat, catchpy and loris roles.
 
 # Apply common configuration to all hosts
-- hosts: all
+- hosts: catchpy:hxat:loris
   
   roles:
     - common-apache2


### PR DESCRIPTION
The `common-apache2` role that installs the `apache2` package was mistakenly added to all deployments.

This PR restricts this role to HxAT-related deployments, specifically hxat, catchpy and loris.