### PR TITLE
Allow for more crontab granular control for tarsnap.

### DIFF
--- a/playbooks/roles/tarsnap/defaults/main.yml
+++ b/playbooks/roles/tarsnap/defaults/main.yml
@@ -47,10 +47,21 @@ TARSNAP_ARCHIVE_NAME: 'backup'
 # Optional snitch to be sent
 TARSNAP_BACKUP_SNITCH: null
 
-# Backups should be daily at most
-TARSNAP_BACKUP_HOUR: '*'
+# Tarsnap backup cron settings.
+# This will be translated to
+# a crontab record. Read https://linux.die.net/man/5/crontab
+# for more info on crontab syntax and
+# https://docs.ansible.com/ansible/2.5/modules/cron_module.html for
+# more info on ansible's cron module.
+# By default backups will happen every hour on the 10th minute.
+# For production instances backups should be daily at most.
+# For stage instances it's OK to do weekly backups.
 # Avoid 0 minute --- as Dead Man's snitch might do false positive then
 TARSNAP_BACKUP_MINUTE: '10'
+TARSNAP_BACKUP_HOUR: '*'
+TARSNAP_BACKUP_DAY: '*'
+TARSNAP_BACKUP_MONTH: '*'
+TARSNAP_BACKUP_WEEKDAY: '*'
 
 TARSNAP_CACHE: "/var/cache/tarsnap"
 

--- a/playbooks/roles/tarsnap/tasks/configure.yml
+++ b/playbooks/roles/tarsnap/tasks/configure.yml
@@ -33,8 +33,11 @@
   cron:
     name: "Backup for this server, archive: {{ TARSNAP_ARCHIVE_NAME }}"
     job: "{{ TARSNAP_BACKUP_SCRIPT_LOCATION }} >> {{ TARSNAP_BACKUP_LOG_FILE }} 2>&1"
-    hour: "{{ TARSNAP_BACKUP_HOUR }}"
     minute: "{{ TARSNAP_BACKUP_MINUTE }}"
+    hour: "{{ TARSNAP_BACKUP_HOUR }}"
+    day: "{{ TARSNAP_BACKUP_DAY }}"
+    month: "{{ TARSNAP_BACKUP_MONTH }}"
+    weekday: "{{ TARSNAP_BACKUP_WEEKDAY }}"
     state: "{{ TARSNAP_CRONTAB_STATE }}"
 
 - name: Set up log rotation for backup logs


### PR DESCRIPTION
Update tarsnap's cron task to allow minute, hour, day, month and week values. Set default to every hour