### PR TITLE
Playbook for setting up an Elastic Stack server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 	path = playbooks/roles/load-balancer
 	url = https://github.com/open-craft/ansible-load-balancer
 	branch = master
+[submodule "playbooks/roles/elastic.elasticsearch"]
+	path = playbooks/roles/elastic.elasticsearch
+	url = https://github.com/elastic/ansible-elasticsearch.git

--- a/playbooks/elasticstack.yml
+++ b/playbooks/elasticstack.yml
@@ -1,0 +1,23 @@
+---
+# Playbook for setting up an Elastic Stack server.
+
+- name: Set up Elastic Stack servers
+  hosts: elasticstack
+  become: true
+  roles:
+    - role: common-server
+      tags: 'common-server'
+
+    - role: elastic.elasticsearch
+      tags: 'elasticstack'
+
+    - role: nginx-proxy
+      vars:
+        NGINX_PROXY_CONFIG_PATH: /etc/nginx/sites-available/elasticsearch
+
+        NGINX_PROXY_AUTH_DOMAIN: Elasticsearch
+        NGINX_PROXY_INTERNAL_PORT: 9200
+        NGINX_PROXY_PUBLIC_PORT: 19200
+
+        NGINX_PROXY_USERNAME: "{{ ELASTICSEARCH_USERNAME }}"
+        NGINX_PROXY_PASSWORD: "{{ ELASTICSEARCH_PASSWORD }}"

--- a/playbooks/group_vars/elasticstack/public.yml
+++ b/playbooks/group_vars/elasticstack/public.yml
@@ -1,0 +1,19 @@
+---
+
+# ELASTICSTACK ###############################################################
+
+es_instance_name: "node1"
+
+es_api_port: 9200
+es_enable_xpack: false
+es_heap_size: 1g
+es_java_install: true
+es_version: "6.5.1"
+es_version_lock: true
+
+es_config:
+  node.data: true
+  node.master: true
+  node.name: ${HOSTNAME}
+  cluster.name: "{{ ELASTICSEARCH_CLUSTER_NAME }}"
+  http.port: 9200


### PR DESCRIPTION
Blockstore uses ElasticSearch 6. This is a role to configure a server to act as a dedicated ElasticSearch server. Currently it is not production ready and may need more configuration in the future.

- Uses the official Ansible role for installing Elastic Stack 6.
- ElasticSearch is behind nginx with basic auth configured.