### PR TITLE
SE-617 Force appserver playbook to reload nginx

### DIFF
--- a/playbooks/appserver.yml
+++ b/playbooks/appserver.yml
@@ -13,3 +13,15 @@
       # Appservers may have some Elastic stuff already installed on them.
       filebeat_elastic_apt_pin: 200
       when: filebeat_logstash_hosts | length > 0
+  tasks:
+    # Bug ref https://github.com/ansible/ansible/issues/11327
+    # (Issue is closed, but bug still exists.)
+    #
+    # Have to force reload nginx to take up the new configuration.
+    # consul meta skips nginx-proxy role when consul_http_password is none,
+    # which causes node-exporter's nginx-proxy "reload nginx" handler to be
+    # skipped as well.
+    - name: reload nginx
+      service:
+        name: nginx
+        state: reloaded

--- a/playbooks/appserver.yml
+++ b/playbooks/appserver.yml
@@ -13,15 +13,3 @@
       # Appservers may have some Elastic stuff already installed on them.
       filebeat_elastic_apt_pin: 200
       when: filebeat_logstash_hosts | length > 0
-  tasks:
-    # Bug ref https://github.com/ansible/ansible/issues/11327
-    # (Issue is closed, but bug still exists.)
-    #
-    # Have to force reload nginx to take up the new configuration.
-    # consul meta skips nginx-proxy role when consul_http_password is none,
-    # which causes node-exporter's nginx-proxy "reload nginx" handler to be
-    # skipped as well.
-    - name: reload nginx
-      service:
-        name: nginx
-        state: reloaded

--- a/playbooks/roles/nginx-proxy/handlers/main.yml
+++ b/playbooks/roles/nginx-proxy/handlers/main.yml
@@ -1,5 +1,0 @@
----
-- name: reload nginx
-  service:
-    name: nginx
-    state: reloaded

--- a/playbooks/roles/nginx-proxy/tasks/main.yml
+++ b/playbooks/roles/nginx-proxy/tasks/main.yml
@@ -17,19 +17,23 @@
   template:
     src: nginx-proxy.j2
     dest: "{{ NGINX_PROXY_CONFIG_PATH }}"
-  notify:
-    - reload nginx
+  register: sites_available
 
 - name: enable nginx site configuration
   file:
     src: "{{ NGINX_PROXY_CONFIG_PATH }}"
     dest: "/etc/nginx/sites-enabled/{{ NGINX_PROXY_CONFIG_PATH | basename }}"
     state: link
-  notify:
-    - reload nginx
+  register: sites_enabled
 
 - name: open public port on the firewall
   ufw:
     rule: allow
     port: "{{ NGINX_PROXY_PUBLIC_PORT }}"
     proto: tcp
+
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded
+  when: sites_available.changed or sites_enabled.changed


### PR DESCRIPTION
Due to an ansible bug, when running the appserver.yml playbook, the `reload nginx` handler is skipped when it should not be.

* When the `consul` role runs, its dependent [`nginx-proxy` meta role is skipped](https://github.com/open-craft/ansible-common-secrets) when [`consul_http_password: null` (default value)](https://github.com/open-craft/ansible-playbooks/blob/f3a5bdeb1c4f263716d200609e89dcd8e626f6d4/playbooks/roles/consul/defaults/main.yml#L55). 
  The variables in our https://github.com/open-craft/ansible-common-secrets repo do not override this default, because we don't need the `consul` nginx proxy to run on our appservers.
* The `node-exporter` also [depends on the `nginx-proxy` role](https://github.com/open-craft/ansible-playbooks/blob/f3a5bdeb1c4f263716d200609e89dcd8e626f6d4/playbooks/roles/node-exporter/meta/main.yml#L7), which is how prometheus checks for node health.
* The `nginx-proxy` role should [trigger its `reload nginx` handler](https://github.com/open-craft/ansible-playbooks/blob/f3a5bdeb1c4f263716d200609e89dcd8e626f6d4/playbooks/roles/nginx-proxy/tasks/main.yml#L20-L21) twice.
   However, when the `appserver.yml` playbook completes and the handlers are flushed, nginx is not reloaded, as shown by the output:
   ```yaml
   RUNNING HANDLER [nginx-proxy : reload nginx]
   *********************************************************************************
   skipping: [172.31.58.138] => {"changed": false, "skip_reason": "Conditional result was False"}
   ```

**JIRA tickets**:SE-617

**Discussions**: https://github.com/ansible/ansible/issues/11327

**Testing instructions**:

1. Run this branch on a fresh edxapp appserver.
1. Note that the `reload nginx` task is run at the end of the palybook, and nginx is reloaded.
   (Though `RUNNING HANDLER [nginx-proxy : reload nginx]` is still skipped.)

**Author notes and concerns**:

1. This issue is not noticeable on Ocim appservers, because they are restarted after running all the playbooks, and so `nginx` is restarted too.
1. I tried putting [`meta: flush_handlers`](https://github.com/open-craft/ansible-playbooks/blob/089f7f50e44c479d22a63a70253999c1d3b55078/playbooks/roles/common-server-init/tasks/nginx.yml#L21-L23) at various places (`nginx-proxy/tasks`, `node-exporter/tasks`, `node-exporter/meta`), but it had no effect.
1. I also tried upgrading ansible from `2.5.1` to the latest `2.7.5`, but it had no effect.
1. I ran the steps described in https://github.com/ansible/ansible/issues/11327 on both `2.5.1` and the latest `2.7.5`, and found that the issue is still occurring, despite the bug being closed.
  Will re-open the bug if this seems useful (https://github.com/ansible/ansible currently has 3,900+ issues open).

**Reviewers**
- [ ] @lgp171188 