### PR TITLE
Update hxat to 1.1.4 and add backups to hxat/catchpy

### DIFF
--- a/playbooks/hxat-catchpy-loris.yml
+++ b/playbooks/hxat-catchpy-loris.yml
@@ -2,10 +2,23 @@
 ## This playbook deploys hxat, catchpy and loris roles.
 
 # Apply common configuration to all hosts
+
 - hosts: catchpy:hxat:loris
   
   roles:
-    - common-apache2
+    # The recommended configuration for these tools involved using apache2.
+    # Our common-server role includes node-exporter, which depends on nginx. We disable node-exporter here
+    # because nginx and apache2 can't coexist without further changes. A better solution would be to move
+    # hxat/catchpy/loris to nginx.
+    - role: common-server
+      COMMON_SERVER_INSTALL_NODE_EXPORTER: false
+      # certbot is installed by the the common-apache2 role
+      COMMON_SERVER_INSTALL_CERTBOT: false
+      # FIXME de-commonize the TARSNAP stuff; we'll need different backup folders in each one of the 3 servers, and different backup script(s)
+      # FIXME add DB dumper script
+      # FIXME add tarsnap key
+      TARSNAP_BACKUP_FOLDERS: "{{ FIXME_ADD_SOME__DOWNLOAD_LOG_DIR }} {{ DALITE_LOG_DOWNLOAD_DB_DIR }}"
+    - role: common-apache2
 
 # Configure and deploy catchpy servers.
 - hosts: catchpy

--- a/playbooks/hxat-catchpy-loris.yml
+++ b/playbooks/hxat-catchpy-loris.yml
@@ -18,9 +18,10 @@
 
   roles:
     - role: tarsnap
-      # FIXME add DB dumper script
-      TARSNAP_KEY: "{{ HXAT_PRODUCTION_RW_TARSNAP_KEY }}"
-      TARSNAP_BACKUP_FOLDERS: "{{ FIXME_ADD_SOME__DOWNLOAD_LOG_DIR }} {{ SOME_LOG_DOWNLOAD_DB_DIR }}"
+      TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/catchpy-pre-backup.sh"
+      TARSNAP_KEY: "{{ CATCHPY_PRODUCTION_RW_TARSNAP_KEY }}"
+      TARSNAP_BACKUP_FOLDERS: "/var/backups/catchpy /etc"
+      TARSNAP_BACKUP_SNITCH: "{{ CATCHPY_TARSNAP_SNITCH }}"
     - role: catchpy
       vars:
         ansible_python_interpreter: /usr/bin/python2
@@ -32,9 +33,10 @@
 
   roles:
     - role: tarsnap
-      # FIXME add DB dumper script
-      TARSNAP_KEY: "{{ CATCHPY_PRODUCTION_RW_TARSNAP_KEY }}"
-      TARSNAP_BACKUP_FOLDERS: "{{ FIXME_ADD_SOME__DOWNLOAD_LOG_DIR }} {{ SOME_LOG_DOWNLOAD_DB_DIR }}"
+      TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/hxat-pre-backup.sh"
+      TARSNAP_KEY: "{{ HXAT_PRODUCTION_RW_TARSNAP_KEY }}"
+      TARSNAP_BACKUP_FOLDERS: "/var/backups/hxat /etc"
+      TARSNAP_BACKUP_SNITCH: "{{ HXAT_TARSNAP_SNITCH }}"
     - role: hxat
       vars:
         ansible_python_interpreter: /usr/bin/python2

--- a/playbooks/hxat-catchpy-loris.yml
+++ b/playbooks/hxat-catchpy-loris.yml
@@ -15,7 +15,7 @@
 
 # Configure and deploy catchpy servers.
 - hosts: catchpy
-
+  become: true
   roles:
     - role: tarsnap
       TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/catchpy-pre-backup.sh"
@@ -30,7 +30,7 @@
 
 # Configure and deploy hxat servers.
 - hosts: hxat
-
+  become: true
   roles:
     - role: tarsnap
       TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/hxat-pre-backup.sh"

--- a/playbooks/hxat-catchpy-loris.yml
+++ b/playbooks/hxat-catchpy-loris.yml
@@ -7,23 +7,20 @@
   
   roles:
     # The recommended configuration for these tools involved using apache2.
-    # Our common-server role includes node-exporter, which depends on nginx. We disable node-exporter here
-    # because nginx and apache2 can't coexist without further changes. A better solution would be to move
-    # hxat/catchpy/loris to nginx.
-    - role: common-server
-      COMMON_SERVER_INSTALL_NODE_EXPORTER: false
-      # certbot is installed by the the common-apache2 role
-      COMMON_SERVER_INSTALL_CERTBOT: false
-      # FIXME de-commonize the TARSNAP stuff; we'll need different backup folders in each one of the 3 servers, and different backup script(s)
-      # FIXME add DB dumper script
-      # FIXME add tarsnap key
-      TARSNAP_BACKUP_FOLDERS: "{{ FIXME_ADD_SOME__DOWNLOAD_LOG_DIR }} {{ DALITE_LOG_DOWNLOAD_DB_DIR }}"
+    # Our common-server role includes common-server-init, which installs nginx and can conflict with apache2.
+    # TODO: Consider using nginx for hxat/catchpy/loris. Or add common-server here to get the rest of features (consul, …)
+    # For now, instead of using common-server we manually add the features we need, e.g. tarsnap for backups
+    # The common-apache2 role also installs certbot
     - role: common-apache2
 
 # Configure and deploy catchpy servers.
 - hosts: catchpy
 
   roles:
+    - role: tarsnap
+      # FIXME add DB dumper script
+      TARSNAP_KEY: "{{ HXAT_PRODUCTION_RW_TARSNAP_KEY }}"
+      TARSNAP_BACKUP_FOLDERS: "{{ FIXME_ADD_SOME__DOWNLOAD_LOG_DIR }} {{ SOME_LOG_DOWNLOAD_DB_DIR }}"
     - role: catchpy
       vars:
         ansible_python_interpreter: /usr/bin/python2
@@ -34,6 +31,10 @@
 - hosts: hxat
 
   roles:
+    - role: tarsnap
+      # FIXME add DB dumper script
+      TARSNAP_KEY: "{{ CATCHPY_PRODUCTION_RW_TARSNAP_KEY }}"
+      TARSNAP_BACKUP_FOLDERS: "{{ FIXME_ADD_SOME__DOWNLOAD_LOG_DIR }} {{ SOME_LOG_DOWNLOAD_DB_DIR }}"
     - role: hxat
       vars:
         ansible_python_interpreter: /usr/bin/python2
@@ -44,6 +45,8 @@
 - hosts: loris
 
   roles:
+    # loris DB/images not backed up with tarsnap since no courses use image annotations yet
+
     - role: loris
       vars:
         ansible_python_interpreter: /usr/bin/python2

--- a/playbooks/roles/catchpy/tasks/main.yml
+++ b/playbooks/roles/catchpy/tasks/main.yml
@@ -37,6 +37,14 @@
   become_user: postgres
   postgresql_user: name={{catchpy_dbuser}} role_attr_flags=NOSUPERUSER,NOCREATEDB
 
+- name: copy pre backup script
+  template:
+    src: catchpy-pre-backup.sh
+    dest: /usr/local/sbin/catchpy-pre-backup.sh
+    owner: root
+    group: root
+    mode: 0700
+
 # catchpy code
 
 - stat: path={{ catchpy_app_path }}

--- a/playbooks/roles/catchpy/templates/catchpy-pre-backup.sh
+++ b/playbooks/roles/catchpy/templates/catchpy-pre-backup.sh
@@ -2,5 +2,6 @@
 # Will exit on first error (we want it!)
 set -e
 
-BACKUPSDIR="/var/backups/catchpy/"
+BACKUPSDIR="/var/backups/catchpy"
+mkdir -p $BACKUPSDIR
 sudo su postgres -c "pg_dumpall" | gzip > ${BACKUPSDIR}/catchpy_db.gz

--- a/playbooks/roles/catchpy/templates/catchpy-pre-backup.sh
+++ b/playbooks/roles/catchpy/templates/catchpy-pre-backup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Will exit on first error (we want it!)
+set -e
+
+BACKUPSDIR="/var/backups/catchpy/"
+sudo su postgres -c "pg_dumpall" | gzip > ${BACKUPSDIR}/catchpy_db.gz

--- a/playbooks/roles/hxat/defaults/main.yml
+++ b/playbooks/roles/hxat/defaults/main.yml
@@ -2,7 +2,7 @@
 
 hxat_app_repository: https://github.com/lduarte1991/hxat
 hxat_app_path: /srv/hxat
-hxat_version: v1.1.3
+hxat_version: v1.1.4
 
 # database
 

--- a/playbooks/roles/hxat/defaults/main.yml
+++ b/playbooks/roles/hxat/defaults/main.yml
@@ -38,6 +38,9 @@ hxat_annotation_db_api_key: 49a70e80-3c06-11e7-a919-92ebcb67fe33
 hxat_annotation_db_secret_token: bd79cd1c-3c06-11e7-a919-92ebcb67fe33
 hxat_annotation_pagination_limit_default: 20
 
+# Show keyboard icon (accessibility tools)
+hxat_accessibility: true
+
 hxat_admin_roles:
   - Admin
   - Instructor

--- a/playbooks/roles/hxat/tasks/main.yml
+++ b/playbooks/roles/hxat/tasks/main.yml
@@ -37,6 +37,14 @@
   become_user: postgres
   postgresql_user: name={{hxat_dbuser}} role_attr_flags=NOSUPERUSER,NOCREATEDB
 
+- name: copy pre backup script
+  template:
+    src: hxat-pre-backup.sh
+    dest: /usr/local/sbin/hxat-pre-backup.sh
+    owner: root
+    group: root
+    mode: 0700
+
 # HxAT Code
 
 - name: remove current code if exists

--- a/playbooks/roles/hxat/templates/hxat-pre-backup.sh
+++ b/playbooks/roles/hxat/templates/hxat-pre-backup.sh
@@ -2,5 +2,6 @@
 # Will exit on first error (we want it!)
 set -e
 
-BACKUPSDIR="/var/backups/hxat/"
+BACKUPSDIR="/var/backups/hxat"
+mkdir -p $BACKUPSDIR
 sudo su postgres -c "pg_dumpall" | gzip > ${BACKUPSDIR}/hxat_db.gz

--- a/playbooks/roles/hxat/templates/hxat-pre-backup.sh
+++ b/playbooks/roles/hxat/templates/hxat-pre-backup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Will exit on first error (we want it!)
+set -e
+
+BACKUPSDIR="/var/backups/hxat/"
+sudo su postgres -c "pg_dumpall" | gzip > ${BACKUPSDIR}/hxat_db.gz

--- a/playbooks/roles/hxat/templates/secure.py.j2
+++ b/playbooks/roles/hxat/templates/secure.py.j2
@@ -20,4 +20,5 @@ SECURE_SETTINGS = {
     'annotation_database_url': '{{ hxat_annotation_db_url }}',
     'annotation_db_api_key': '{{ hxat_annotation_db_api_key }}',
     'annotation_db_secret_token': '{{ hxat_annotation_db_secret_token }}',
+    'accessibility': {{ hxat_accessibility }},
 }


### PR DESCRIPTION
This upgrades hxat to 1.1.4, which introduces a variable which we can use to disable the keyboard icon shown in this image:

![image001](https://user-images.githubusercontent.com/132703/51400633-9190d600-1b51-11e9-8c0d-d5e5183047c6.png)

This is a temporary fix until we have other accessibility fixes.

Use together with https://github.com/open-craft/ansible-secrets/pull/99

In addition, it introduces tarsnap backup scripts for hxat's DB and catchpy's DB. No files require backup, just DBs. loris doesn't require backup because we're not using image annotations yet so there aren't user files in the server.


Testing instructions:

For the icon, enter into a lesson that has this LTI component [(example)](https://edge.edx.org/courses/course-v1:MITx+HXAT-MITx+2018/courseware/96e8b28c6a874b9b9afff7b371d4b63d/8db6619a7fe54880a52b8e553bdb8428/2?activate_block_id=block-v1%3AMITx%2BHXAT-MITx%2B2018%2Btype%40vertical%2Bblock%40114049084e794828a9deba7ac24e6f53), to check that the icon isn't there (compare with screenshot), 

For backups: we'll deploy hxat/catchpy and check that the new common-server role works and that tarsnap archives are created, can be restored, and DeadManSnitch snitches are activated.
We're also deploying backup-pruner.
See instructions, IPs, accesses and SSH keys in SE-361.
