### PR TITLE
(BB-212) Add post task to make sure admin user has extra custom roles.

### DIFF
--- a/playbooks/mongodb.yml
+++ b/playbooks/mongodb.yml
@@ -13,3 +13,11 @@
 
     - role: greendayonfire.mongodb
       tags: 'greendayonfire.mongodb'
+
+  post_tasks:
+      - name: "Make sure admin user has extra custom mongo roles."
+        command: >
+            mongo --quiet -u {{ mongodb_user_admin_name }} \
+                -p {{ mongodb_user_admin_password }} --port {{ mongodb_net_port}}
+                --eval 'db.grantRolesToUser("{{ mongodb_user_admin_name}}", ["{{item.role}}"])' {{item.db}}
+        with_items: {{ mongodb_user_admin_roles }}


### PR DESCRIPTION
We use `greendayonfire.mongodb` ansible role to setup and configure mongodb. That role creates an admin user and add a hard-coded ([userAdminAnyDatabase](https://github.com/UnderGreen/ansible-role-mongodb/blob/master/tasks/auth_initialization.yml#L34)) role to that user. We have to add another role ([dbAdminAnyDatabase](https://docs.mongodb.com/manual/reference/built-in-roles/#dbAdminAnyDatabase)) to that user so we can drop databases with the user admin.
There's a [PR](https://github.com/UnderGreen/ansible-role-mongodb/pull/142) submitted to upstream so the `greendayonfire.mongodb` ansible role will allow us to add extra custom roles. But, the `greendayonfire.mongodb` ansible role only configures the user admin if the username [does not exists](https://github.com/UnderGreen/ansible-role-mongodb/blob/master/tasks/main.yml#L31) in the mongodb instance.
This PR adds a `post_task` after setting up mongo to make sure that the admin user has the extra mongo roles we'll need to add. Since `db.grantRolesToUser` is idempotent we can run the command every time we run the playbook. We also make sure the correct roles are always added to the admin user even if somebody modify that manually.