### PR TITLE
[BB-870] Add filebeat config for vault logs.

### DIFF
--- a/playbooks/group_vars/load-balancer/public.yml
+++ b/playbooks/group_vars/load-balancer/public.yml
@@ -71,6 +71,10 @@ filebeat_prospectors:
     paths:
       - /var/log/syslog
     include_lines: ['nomad']
+  - fields:
+      type: "vault"
+    paths:
+      - "/var/log/vault/*.log"
 
 # PROMETHEUS ##################################################################
 


### PR DESCRIPTION
Test Instructions:

1. Go to logs.opencraft.com
1. Go to the "Discover" page
1. Give search query `type: vault`
1. Ensure logs are showing up