### PR TITLE
[BB-840] Fix precedence issue of 'caching_resolver_enabled' variable

### DIFF
--- a/playbooks/load-balancer.yml
+++ b/playbooks/load-balancer.yml
@@ -4,8 +4,6 @@
 - name: Set up load-balancing servers
   hosts: load-balancer
   become: true
-  vars:
-    caching_resolver_enabled: false
   roles:
     - role: common-server
       tags: 'common-server'
@@ -17,5 +15,5 @@
       tags: 'node-exporter'
 
     - role: unbound
-      when: caching_resolver_enabled
+      when: "{{ caching_resolver_enabled | default(false) }}"
       tags: 'unbound'


### PR DESCRIPTION
The `caching_resolver_enabled` variable defined in the `load-balancer.yml` took precedence over the `host_vars` variable defined for the host. This PR fixes that issue.

Run
```
ansible-playbook -vvv -C --diff deploy/playbooks/deploy-all.yml  -l "<host/group on which unbound should be installed>" --tags "unbound"
```
and

```
ansible-playbook -vvv -C --diff deploy/playbooks/deploy-all.yml  -l "<host/group on which unbound shouldn't be installed>" --tags "unbound"
```

and verify that result is as expected.