### PR TITLE
[BB-840] Fix the when condition to not use jinja2 delimiters and apt module warning

### DIFF
--- a/playbooks/load-balancer.yml
+++ b/playbooks/load-balancer.yml
@@ -15,5 +15,5 @@
       tags: 'node-exporter'
 
     - role: unbound
-      when: "{{ caching_resolver_enabled | default(false) }}"
+      when: "caching_resolver_enabled | default(false)"
       tags: 'unbound'

--- a/playbooks/roles/unbound/tasks/main.yml
+++ b/playbooks/roles/unbound/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install unbound and resolvconf
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - unbound
     - resolvconf


### PR DESCRIPTION
Fixes the below warning

```
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: "{{ caching_resolver_enabled | default(false) }}"
```

and the warning from the `apt` module that the `installed` state is deprecated and that the `present` state should be used.