### PR TITLE
Adjust LPD logging settings

### DIFF
--- a/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
@@ -31,46 +31,74 @@ if getpass.getuser() == '{{ LPD_USER_NAME }}':
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
-            'timestamped': {
-                'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+            'timestamp_formatter': {
+                'format': '[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s',
             },
         },
         'handlers': {
-            'file_debug_log': {
-                'level': 'DEBUG',
+            'file_info_log_django': {
+                'level': 'INFO',
                 'class': 'logging.FileHandler',
-                'filename': '{{ LPD_LOG_DIR }}/debug.log',
-                'formatter': 'timestamped',
+                'formatter': 'timestamp_formatter',
+                'filename': '{{ LPD_LOG_DIR }}/django.log',
             },
-            'file_test_log': {
+            'file_debug_log_default': {
                 'level': 'DEBUG',
                 'class': 'logging.FileHandler',
+                'formatter': 'timestamp_formatter',
+                'filename': '{{ LPD_LOG_DIR }}/default.log',
+            },
+            'file_debug_log_security': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'formatter': 'timestamp_formatter',
+                'filename': '{{ LPD_LOG_DIR }}/security.log',
+            },
+            'file_debug_log_test': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'formatter': 'timestamp_formatter',
                 'filename': '{{ LPD_LOG_DIR }}/test.log',
             },
         },
         'loggers': {
             'django.request': {
-                'handlers': ['file_debug_log'],
+                'handlers': ['file_info_log_django'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
+            'django.server': {
+                'handlers': ['file_info_log_django'],
+                'level': 'INFO',
+                'propagate': False,
+            },
+            'django.template': {
+                'handlers': ['file_info_log_django'],
+                'level': 'INFO',
+                'propagate': False,
+            },
+            'django.security': {
+                'handlers': ['file_debug_log_security'],
                 'level': 'DEBUG',
                 'propagate': True,
             },
             'django_lti_tool_provider.views': {
-                'handlers': ['file_debug_log'],
+                'handlers': ['file_debug_log_default'],
                 'level': 'DEBUG',
                 'propagate': True,
             },
             'lpd.views': {
-                'handlers': ['file_debug_log'],
+                'handlers': ['file_debug_log_default'],
                 'level': 'DEBUG',
                 'propagate': True,
             },
             'lpd.client': {
-                'handlers': ['file_debug_log'],
+                'handlers': ['file_debug_log_default'],
                 'level': 'DEBUG',
                 'propagate': True,
             },
             'lpd.tests': {
-                'handlers': ['file_test_log'],
+                'handlers': ['file_debug_log_test'],
                 'level': 'DEBUG',
                 'propagate': True,
             },


### PR DESCRIPTION
 ... to match [recent changes](https://github.com/open-craft/learner-profile-dashboard/pull/17) to defaults in learner-profile-dashboard repo.

**Test instructions**

Changes have been deployed to [LPD stage](https://lpd-stage.opencraft.hosting/) for verification.

1. SSH into LPD stage via `ssh ubuntu@lpd-stage.opencraft.hosting`. (I added your GitHub key to this instance.)

1. Start watching the new log files via `tail -f /var/log/lpd/default.log /var/log/lpd/django.log /var/log/lpd/security.log`.

1. Navigate to [HGSE stage](https://hgse-stage.opencraft.hosting/) and proceed with the test instructions from https://github.com/open-craft/learner-profile-dashboard/pull/18. Observe that the logs will update as you step through the test instructions for that PR.
    * Note that not all of them will necessarily update. That's fine, this is just about making sure that the new logging configuration doesn't throw any errors.
    * This PR doesn't make any changes to the deployment procedure for https://github.com/open-craft/learner-profile-dashboard/, so there is no need to step through a deployment to test them.

**Reviewers**

- [x] @DevanR 