### PR TITLE
BB-1030 Add install JS dependencies to OCIM delpoyment playbook.

### DIFF
--- a/playbooks/roles/ocim/tasks/common.yml
+++ b/playbooks/roles/ocim/tasks/common.yml
@@ -16,3 +16,8 @@
     virtualenv: "{{ opencraft_virtualenv_dir }}"
     virtualenv_python: python3.5
   become_user: "{{ www_user }}"
+
+- name: Install JS dependencies
+  command: make install_js_dependencies
+  args:
+      chdir: "{{ opencraft_root_dir }}"


### PR DESCRIPTION
Add `make install_js_dependencies` to OCIM deployment playbook. By installing the dependencies needed for JavaScript we end up with a fully functional OCIM environment in the local Vagrant VM.
This [make target](https://github.com/open-craft/opencraft/pull/426/files#diff-b67911656ef5d18c4ae36cb6741b7965R77) will install node and everything in `package.json` using `npm`.

This playbook is also used when deploying OCIM to stage and production. As of the creation of this PR we only need the JavaScript libraries in the local Vagrant vm to run JS tests (karma + jasmine). But, this is laying the ground work needed to eventually not track JS vendor libraries and use npm (or yarn) to install these libraries as well as using webpack (or browserify) to do some processing to the JS code.