### PR TITLE
Raise JVM heap size to 4 Gb for ElasticSearch

### DIFF
--- a/playbooks/group_vars/elasticstack/public.yml
+++ b/playbooks/group_vars/elasticstack/public.yml
@@ -6,7 +6,7 @@ es_instance_name: "node1"
 
 es_api_port: 9200
 es_enable_xpack: false
-es_heap_size: 1g
+es_heap_size: 4g
 es_java_install: true
 es_version: "6.5.1"
 es_version_lock: true


### PR DESCRIPTION
Our ElasticSearch (in the ELK server) was suffering with 1 Gb of heap. With 4 Gb it ran fine. The server has 16 Gb.

People mention ([e.g.](https://support.cloudbees.com/hc/en-us/articles/218888897-Elasticsearch-NoShardAvailableActionException)) that 2 Gb isn't enough for big collections; our indices are >280 Gb, and ElasticSearch was hanging in many cases with big queries (e.g. whole-year logs), so I think 4 will work. They even recommend giving half the RAM to Lucene.
If we give too much RAM, less can be used for OS cache. We may have to find the right compromise.

With 4 Gb heap, this is the :
```
root@logs:~# free -m
              total        used        free      shared  buff/cache   available
Mem:          15951        6214         181           1        9554        9402
Swap:          1021         426         595
```

These modification end up in /etc/elasticsearch/jvm.options ([template](https://github.com/elastic/ansible-elasticsearch/blob/master/templates/jvm.options.j2)).

Testing instructions:
- run the playbook against the server? (or a new server)
- or just check that the right number was changed, from 1 to 4
