### PR TITLE
[SE-954] Add PATH to cron job to renew hxat certificates

### DIFF
--- a/playbooks/roles/common-apache2/templates/certbot-renew.sh
+++ b/playbooks/roles/common-apache2/templates/certbot-renew.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+PATH=/usr/bin:/bin:/usr/sbin
 a2ensite 000-default.conf
 service apache2 reload
 certbot renew


### PR DESCRIPTION
This adds `/usr/sbin` to the PATH of the cron job. That should be enough:

```
root@mit-loris:~# whereis a2ensite certbot service apache2ctl
a2ensite: /usr/sbin/a2ensite /usr/share/man/man8/a2ensite.8.gz
certbot: /usr/bin/certbot
service: /usr/sbin/service /usr/share/man/man8/service.8.gz
apache2ctl: /usr/sbin/apache2ctl /usr/share/man/man8/apache2ctl.8.gz
```
The cron job was running with `PATH=/usr/bin:/bin` and it didn't work before because it couldn't run `a2ensite` and therefore it didn't commute the apache config. 

We also had `certbot` hinting at missing paths.
```
/var/log/letsencrypt/letsencrypt.log:2019-04-18 00:07:27,235:DEBUG:certbot.plugins.util:Can't find apache2ctl, attempting PATH mitigation by adding /usr/sbin:/usr/local/bin:/usr/local/sbin
```

Test:
- experiment with cron: change the frequency to run the script today to simulate that renewals are due today
- check the results at `/var/log/letsencrypt/letsencrypt.log` and `/var/log/syslog`
- in the long term, check that the scripts renews the certificates (this only happens when they expire in less than 30 days)
- check that it's installed in all 3 servers