### PR TITLE
Add storage settings for LPD

### DIFF
--- a/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
+++ b/playbooks/roles/learner-profile-dashboard/templates/lpd_settings.py
@@ -111,6 +111,12 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = "{{ LPD_MEDIA_ROOT }}"
 MEDIA_URL = "/media/"
 
+USE_REMOTE_STORAGE = True
+
+AWS_ACCESS_KEY_ID = "{{ LPD_AWS_ACCESS_KEY_ID }}"
+AWS_SECRET_ACCESS_KEY = "{{ LPD_AWS_SECRET_ACCESS_KEY }}"
+AWS_STORAGE_BUCKET_NAME = "{{ LPD_AWS_STORAGE_BUCKET_NAME }}"
+
 # List of knowledge component IDs for which LDA model calculates probabilities.
 # The order of the components must match exactly the order in which probabilities are returned by LDA model.
 # E.g. If LDA model returns [0.2, 0.8] and GROUP_KCS are equal to ['kc_id_1', 'kc_id_2'],


### PR DESCRIPTION
Cf. [SE-980](https://tasks.opencraft.com/browse/SE-980)

Updates template for `local_settings.py` to include storage settings introduced via https://github.com/open-craft/learner-profile-dashboard/pull/21.

**Related PRs**

* https://github.com/open-craft/learner-profile-dashboard/pull/21
* https://github.com/open-craft/ansible-secrets/pull/118

**Test instructions**

This PR doesn't make any fundamental changes to the deployment procedure for https://github.com/open-craft/learner-profile-dashboard/, so there is no need to step through a full re-deployment to test them. Just make sure that the names of the three variables introduced here (`LPD_AWS_ACCESS_KEY_ID`, `LPD_AWS_SECRET_ACCESS_KEY`, and `LPD_AWS_STORAGE_BUCKET_NAME`) match those of the variables added to secrets for LPD stage and LPD prod via https://github.com/open-craft/ansible-secrets/pull/118.

**Reviewers**

- [x] @pkulkark 