### PR TITLE
Fix RabbitMQ dependencies.

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -17,8 +17,8 @@ ERLANG_REPO_KEY: "http://packages.erlang-solutions.com/debian/erlang_solutions.a
 RABBITMQ_REPO: "deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ {{ ansible_distribution_release }} main"
 RABBITMQ_REPO_KEY: "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
 
-ERLANG_VERSION: 1:20.1-1
-RABBITMQ_VERSION: 3.6.14-1
+ERLANG_VERSION: "1:20.1"
+RABBITMQ_VERSION: "3.6.14-1"
 
 RABBITMQ_APT_PACKAGES:
   - apt-transport-https

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -36,7 +36,7 @@
     name: "{{ item }}"
     selection: install
   with_items:
-    - erlang-nox
+    - esl-erlang
     - rabbitmq-server
   ignore_errors: yes
   tags:
@@ -45,7 +45,7 @@
 - name: install rabbitmq
   apt:
     name:
-      - "erlang-nox={{ ERLANG_VERSION }}"
+      - "esl-erlang={{ ERLANG_VERSION }}"
       - "rabbitmq-server={{ RABBITMQ_VERSION }}"
     update_cache: yes
     force: yes
@@ -57,7 +57,7 @@
     name: "{{ item }}"
     selection: hold
   with_items:
-    - erlang-nox
+    - esl-erlang
     - rabbitmq-server
   tags:
     - install_rabbitmq


### PR DESCRIPTION
The erlang-nox packange no longer cleanly installs on Ubuntu 16.04.

This patch switches to esl-erlang which is still working instead.

**Note**:

- This cleanly installs on a system that doesn't have `esl-erlang` or `rabbitmq-server` already installed, but will fail if they are already installed on the server, even if the versions are identical to the ones we're trying to install. The reason is that the "Unlock erlang and rabbitmq" step in the rabbitmq role causes existing installations to get upgraded to latest versions, which in theory should be fine because we downgrade them in the next step ("install rabbitmq"), but `rabbitmq-server` does not downgrade cleanly for some reason. It complains about locks on the mnesia folder. Perhaps a fix is to just stop rabbitMQ server before performing the downgrade and then start it after.
- When I last ran the playbook it got stuck on the "fetch the rabbitmqadmin script from the management webserver" step. I didn't have time to re-run to check whether that was just a temporary glitch or if the role is broken. We should make sure.

**How to test**:

1. Find a suitable RabbitMQ VM/server and update the `hosts` file from ansible-secrets so that only that VM/server is included under the RABBITMQ section.
1. Make sure that VM does NOT have `esl-erlang`, `erlang-nox`, or `rabbitmq-server` already installed. Remove them with `sudo apt-get remove <name>` if necessary.
1. Run `ansible-playbook -vvv deploy/playbooks/deploy-all.yml --private-key /path/to/private-key.pem -l rabbitmq`
1. Verify that erlang and rabbitmq get installed correctly on the VM.