### PR TITLE
[BB-1009] Update template to work with single K/V format for config

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
@@ -11,3 +11,14 @@
 {{ $load_balanced_domain }} be-{{ $domain_slug }}
 {{- end }}
 {{- end }}
+
+{{- /* Print config in the form of a single K/V value. */ -}}
+{{- range ls $prefix }}
+  {{- with $config := .Value | parseJSON }}
+    {{- if $config }}
+      {{- range $lb_domain := $config.domains }}
+{{ $lb_domain }} be-"{{ $config.domain_slug }}"
+      {{- end }}
+    {{- end}}
+  {{- end }}
+{{- end }}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -121,3 +121,24 @@ backend be-{{ $domain_slug }}
     server appserver-{{ .id }} {{ .public_ip }}:80 cookie appserver-{{ .id }} {{ if $health_check }}check{{ end }}
     {{- end }}
 {{- end }}
+
+
+{{- /* Print config in the form of a single K/V value. */ -}}
+{{- range ls $prefix }}
+  {{- with $config := .Value | parseJSON }}
+    {{- if $config }}
+    {{ $health_check := $config.health_checks_enabled | parseBool }}
+# Backend configuration for {{ $config.domain }}
+backend be-"{{$config.domain_slug}}"
+    cookie openedx-backend insert postonly indirect
+    acl has-authorization req.hdr(Authorization) -m found
+    http-request set-header Authorization 'Basic "{{ $config.basic_auth }}"' unless has-authorization
+    option httpchk /heartbeat
+    {{- /* Loop over all active appservers for this instance. */ -}}
+    {{- /* Each appserver in this list is a dict of the form {id: int, public_ip: str}. */ -}}
+    {{- range $config.active_app_servers }}
+    server appserver-{{ .id }} {{ .public_ip }}:80 cookie appserver-{{ .id }} {{ if $health_check }}check{{ end }}
+    {{- end }}
+    {{- end}}
+  {{- end }}
+{{- end }}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -127,7 +127,7 @@ backend be-{{ $domain_slug }}
 {{- range ls $prefix }}
   {{- with $config := .Value | parseJSON }}
     {{- if $config }}
-    {{ $health_check := $config.health_checks_enabled | parseBool }}
+    {{ $health_check := $config.health_checks_enabled }}
 # Backend configuration for {{ $config.domain }}
 backend be-"{{$config.domain_slug}}"
     cookie openedx-backend insert postonly indirect


### PR DESCRIPTION
The Ocim instance's configuration is being saved as a single K/V value. This PR takes that into consideration and is also backwards compatible to handle multiple k/v pairs for configuration.
There are two templates that use consul values (backend and haproxy config templates).
Given a test consul values of:
```python
 [{'CreateIndex': 83,
   'Flags': 0,
   'Key': 'ocim/instances/1',
   'LockIndex': 0,
   'ModifyIndex': 83,
   'Value': b'{"domain_slug": "instance-slug", "basic_auth": "asdf", "health_checks_enabled": "false", "version": 1, "domain": "locahost.domain", "active_app_servers": [], "name": "instance 1", "domains": ["lms.localhost.domain", "studio.localhost.domain"]}'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/active_app_servers',
   'LockIndex': 0,
   'ModifyIndex': 224,
   'Value': b'[]'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/basic_auth',
   'LockIndex': 0,
   'ModifyIndex': 224,
   'Value': b'"asdf"'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/domain',
   'LockIndex': 0,
   'ModifyIndex': 224,
   'Value': b'"locahost-2.domain"'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/domain_slug',
   'LockIndex': 0,
   'ModifyIndex': 224,
   'Value': b'"instance-slug-2"'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/domains',
   'LockIndex': 0,
   'ModifyIndex': 224,
   'Value': b'["lms.localhost-2.domain", "studio.localhost-2.domain"]'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/health_checks_enabled',
   'LockIndex': 0,
   'ModifyIndex': 345,
   'Value': b'false'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/name',
   'LockIndex': 0,
   'ModifyIndex': 224,
   'Value': b'"instance 2"'},
  {'CreateIndex': 224,
   'Flags': 0,
   'Key': 'ocim/instances/2/version',
   'LockIndex': 0,
   'ModifyIndex': 345,
   'Value': b'2'}])
```
This PR updates the templates so they will create this output (only the important section is shown here and not the output generated by jinja):
```
# haproxy.cfg.tmpl output
# Backend configuration for "locahost-2.domain"
backend be-"instance-slug-2"
    cookie openedx-backend insert postonly indirect
    acl has-authorization req.hdr(Authorization) -m found
    http-request set-header Authorization 'Basic "asdf"' unless has-authorization
    option httpchk /heartbeat

# Backend configuration for locahost.domain
backend be-"instance-slug"
    cookie openedx-backend insert postonly indirect
    acl has-authorization req.hdr(Authorization) -m found
    http-request set-header Authorization 'Basic "asdf"' unless has-authorization
    option httpchk /heartbeat
```
```
# bakend.map.ctmpl output
lms.localhost-2.domain be-"instance-slug-2"
studio.localhost-2.domain be-"instance-slug-2"
lms.localhost.domain be-"instance-slug"
studio.localhost.domain be-"instance-slug"
```

# Testing instructions.
1. Run the Test instruction from [OCIM-441](https://github.com/open-craft/opencraft/pull/441)
2. Copy the templates from `playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl` and `playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl` to a folder outside the project.
3. Modify the copied templates and remove any jinja2 specific language. We need to only keep the [consul-template](https://github.com/hashicorp/consul-template) specific language so we can manually test this.
4. Run `consul-template -template "haproxy.cfg.tmpl:haproxy.cfg" -once`
5. Make sure the haproxy configuration is created correctly based on the previously instances created.
6. Run `consul-template -template "backend.map.tmpl:backend.map" -once`
7. Make sure the backend mapping is created correctly based on the previously instances created.