### PR TITLE
[SE-1328] Append +letsencrypt to account email

### DIFF
--- a/playbooks/roles/cert-manager/defaults/main.yml
+++ b/playbooks/roles/cert-manager/defaults/main.yml
@@ -5,7 +5,7 @@
 cert_manager_path: "/opt/cert-manager"
 
 cert_manager_stage: true
-cert_manager_email: "ops@opencraft.com"
+cert_manager_email: "ops+letsencrypt@opencraft.com"
 cert_manager_log_level: "debug"
 cert_manager_webroot_path: "/var/www/certbot"
 


### PR DESCRIPTION
This is a transitional change. In the short term, it will allow better filtering for the ops@ list.

Later, we might want to change the address to a separate one, once we are monitoring certificate expiration.

Before this PR is merged, we need to run `certbot update_account --email ops+letsencrypt@opencraft.com`.