### PR TITLE
Automate the manual steps for rabbitmq

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -29,3 +29,10 @@ RABBITMQ_SCRIPTS_DIR: /usr/local/sbin
 
 RABBITMQ_BACKUP_COMMAND: rabbitmq-backup
 RABBITMQ_RESTORE_COMMAND: rabbitmq-restore
+
+RABBITMQ_USER: set-me-please
+RABBITMQ_PASS: set-me-please
+RABBITMQ_VHOST: set-me-please
+
+# Update the version below if RABBITMQ_VERSION is changed
+RABBITMQADMIN_URL: https://raw.githubusercontent.com/rabbitmq/rabbitmq-management/v3.6.x/bin/rabbitmqadmin

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -119,12 +119,10 @@
 
 - name: set letsencrypt directory owner
   file:
-    path: "/etc/letsencrypt/{{ item }}"
+    path: "/etc/letsencrypt"
     owner: rabbitmq
     state: directory
-  with_items:
-    - live
-    - archive
+    recurse: yes
 
 - name: write rabbitmq configuration
   template:
@@ -155,20 +153,29 @@
 # HTTP API, and we need the HTTP API to fetch the rabbitmqadmin tool, so the handlers are flushed here.
 - meta: flush_handlers
 
-- name: fetch the rabbitmqadmin script from the management webserver
-  get_url:
-    url: "https://{{ RABBITMQ_HOSTNAME }}:{{ RABBITMQ_HTTPS_PORT }}/cli/rabbitmqadmin"
-    dest: "{{ RABBITMQ_SCRIPTS_DIR }}/rabbitmqadmin"
-    owner: root
-    group: root
-    mode: 0700
+- name: download rabbitmqadmin executable
+  command: wget -P "{{ RABBITMQ_SCRIPTS_DIR }}" "{{ RABBITMQADMIN_URL }}" creates=rabbitmqadmin
 
 - name: remove default guest user
   rabbitmq_user:
     user: guest
     state: absent
 
+- name: add rabbitmq vhost
+  rabbitmq_vhost:
+    name: "{{ RABBITMQ_VHOST }}"
+    node: "rabbit@{{ RABBITMQ_HOSTNAME }}"
+    state: present
+
+- name: create rabbitmq user
+  rabbitmq_user:
+    user: "{{ RABBITMQ_USER }}"
+    password: "{{ RABBITMQ_PASS }}"
+    vhost: "{{ RABBITMQ_VHOST }}"
+    state: present
+
 - name: ensure vhost /test is present
   rabbitmq_vhost:
     name: /test
+    node: "rabbit@{{ RABBITMQ_HOSTNAME }}"
     state: present

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -154,7 +154,9 @@
 - meta: flush_handlers
 
 - name: download rabbitmqadmin executable
-  command: wget -P "{{ RABBITMQ_SCRIPTS_DIR }}" "{{ RABBITMQADMIN_URL }}" creates=rabbitmqadmin
+  command: wget -P "{{ RABBITMQ_SCRIPTS_DIR }}" "{{ RABBITMQADMIN_URL }}"
+  args:
+    creates: "{{ RABBITMQ_SCRIPTS_DIR }}/rabbitmqadmin"
 
 - name: remove default guest user
   rabbitmq_user:


### PR DESCRIPTION
This PR adds the manual steps for rabbitmq deployment into the ansible playbook. The changes are as follows:

- Set letsencrypt directory owner to rabbitmq

- Add vhost and user

- Download rabbitadmin executable
