### PR TITLE
[BB-1247] Change `docker_compose` to `docker_service` for older ansible

### DIFF
--- a/playbooks/roles/sprints/tasks/main.yml
+++ b/playbooks/roles/sprints/tasks/main.yml
@@ -1,6 +1,6 @@
 # This is required for `common-sever` role to pass, because Let's Encrypt uses Nginx on port 80, which is being used by this container.
 - name: Stop Sprints
-  docker_compose:
+  docker_service:
     project_src: "{{ APP_PATH }}"
     stopped: yes
     debug: yes
@@ -66,7 +66,7 @@
     - sprints
 
 - name: Start Sprints with docker-compose
-  docker_compose:
+  docker_service:
     project_src: "{{ APP_PATH }}"
     pull: yes
     debug: yes


### PR DESCRIPTION
This fixes [this error](https://github.com/open-craft/ansible-secrets/pull/129#issuecomment-515985480) by replacing module name with the one used before Ansible 2.8.