### PR TITLE
BB-1535: Add configuration to enable HAProxy Stats page

### DIFF
--- a/playbooks/roles/load-balancer-v2/defaults/main.yml
+++ b/playbooks/roles/load-balancer-v2/defaults/main.yml
@@ -15,7 +15,7 @@ haproxy_ocim_certs_dir: "/etc/haproxy/certs/ocim"
 haproxy_enable_stats_page: false
 haproxy_stats_port: 8404
 haproxy_stats_page_username: "haproxy"
-haproxy_stats_page_password: null
+haproxy_stats_page_password: "set-me-please"
 
 # Configuration for Nginx server serving maintenance pages.
 maintenance_server_port: 8888

--- a/playbooks/roles/load-balancer-v2/defaults/main.yml
+++ b/playbooks/roles/load-balancer-v2/defaults/main.yml
@@ -12,6 +12,11 @@ haproxy_consul_lock_prefix: "lock/ocim/"
 haproxy_consul_certs_prefix: "ocim/certs"
 haproxy_ocim_certs_dir: "/etc/haproxy/certs/ocim"
 
+haproxy_enable_stats_page: false
+haproxy_stats_port: 8404
+haproxy_stats_page_username: "haproxy"
+haproxy_stats_page_password: null
+
 # Configuration for Nginx server serving maintenance pages.
 maintenance_server_port: 8888
 maintenance_scheduled_server_port: "{{ maintenance_server_port + 1 }}"

--- a/playbooks/roles/load-balancer-v2/tasks/main.yml
+++ b/playbooks/roles/load-balancer-v2/tasks/main.yml
@@ -76,8 +76,13 @@
 - name: Open HTTP and HTTPS port on the firewall
   ufw:
     rule: allow
-    port: "{{ item }}"
+    port: "{{ item.post }}"
     proto: tcp
   with_items:
-    - 80
-    - 443
+    - enabled: true
+      port: 80
+    - enabled: true
+      port: 443
+    - enabled: "{{ haproxy_enable_stats_page }}"
+      port: "{{ haproxy_stats_port }}"
+  when: item.enabled

--- a/playbooks/roles/load-balancer-v2/tasks/main.yml
+++ b/playbooks/roles/load-balancer-v2/tasks/main.yml
@@ -76,7 +76,7 @@
 - name: Open HTTP and HTTPS port on the firewall
   ufw:
     rule: allow
-    port: "{{ item.post }}"
+    port: "{{ item.port }}"
     proto: tcp
   with_items:
     - enabled: true

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -74,6 +74,15 @@ frontend fe_https
     errorloc 503 /error
     errorloc 504 /error
 
+{{! if haproxy_enable_stats_page !}}
+frontend stats
+    bind *:{{! haproxy_stats_port !}} ssl crt /etc/haproxy/certs.pem
+    stats enable
+    stats uri /stats
+    stats refresh 10s
+    stats auth {{! haproxy_stats_page_username !}}:{{! haproxy_stats_page_password !}}
+{{! endif !}}
+
 backend be_acme_challenge
     server srv_lets_encrypt {{! cert_manager_server_address !}}
 

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -74,14 +74,14 @@ frontend fe_https
     errorloc 503 /error
     errorloc 504 /error
 
-{{! if haproxy_enable_stats_page !}}
+{% if haproxy_stats_enable %}
 frontend stats
     bind *:{{! haproxy_stats_port !}} ssl crt /etc/haproxy/certs.pem
     stats enable
     stats uri /stats
     stats refresh 10s
     stats auth {{! haproxy_stats_page_username !}}:{{! haproxy_stats_page_password !}}
-{{! endif !}}
+{% endif %}
 
 backend be_acme_challenge
     server srv_lets_encrypt {{! cert_manager_server_address !}}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -74,7 +74,7 @@ frontend fe_https
     errorloc 503 /error
     errorloc 504 /error
 
-{% if haproxy_stats_enable %}
+{% if haproxy_enable_stats_page %}
 frontend stats
     bind *:{{! haproxy_stats_port !}} ssl crt /etc/haproxy/certs.pem
     stats enable


### PR DESCRIPTION
This PR adds a few configuration variables to the new load balancers to enable the stats page for each HAProxy server.

Review instructions on https://github.com/open-craft/ansible-common-secrets/pull/14

**Reviewer:**
- [x] @SSPJ 