### PR TITLE
BB-1534: Remove rendering from old Ocim kv format

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
@@ -1,16 +1,5 @@
 #jinja2:variable_start_string:'{{!', variable_end_string:'!}}'
 {{- $prefix := "/ocim/instances" }}
-{{- /* Loop over all instances. */ -}}
-{{- /* $pairs here refers to the key/value pairs at each /ocim/instances/<ID> */ -}}
-{{ range $instance_id, $pairs := tree $prefix | byKey }}
-{{- /* Get the value at the "domain_slug" key for this instance, i.e. /ocim/instances/$instance_id/domain_slug */ -}}
-{{- $domain_slug := (index $pairs "domain_slug").Value }}
-{{- $load_balanced_domains := (index $pairs "domains").Value | parseJSON }}
-{{- /* Loop over all of the domains associated with this instance, and map them to the same backend, `be-$domain_slug`. */ -}}
-{{- range $load_balanced_domain := $load_balanced_domains }}
-{{ $load_balanced_domain }} be-{{ $domain_slug }}
-{{- end }}
-{{- end }}
 
 {{- /* Print config in the form of a single K/V value. */ -}}
 {{- range ls $prefix }}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -112,26 +112,6 @@ backend provisioning
     server provisioning-page 127.0.0.1:{{! maintenance_provisioning_server_port !}}
 
 {{- $prefix := "/ocim/instances" }}
-{{ range $instance_id, $pairs := tree $prefix | byKey }}
-{{- $http_auth_info_base64 := (index $pairs "basic_auth").Value }}
-{{- $active_app_servers := (index $pairs "active_app_servers").Value | parseJSON }}
-{{- $domain := (index $pairs "domain").Value }}
-{{- $domain_slug := (index $pairs "domain_slug").Value }}
-{{ $health_check := (index $pairs "health_checks_enabled").Value | parseBool }}
-# Backend configuration for {{ $domain }}
-backend be-{{ $domain_slug }}
-    cookie openedx-backend insert postonly indirect
-    acl has-authorization req.hdr(Authorization) -m found
-    http-request set-header Authorization 'Basic {{ $http_auth_info_base64 }}' unless has-authorization
-    option httpchk /heartbeat
-    {{- /* Loop over all active appservers for this instance. */ -}}
-    {{- /* Each appserver in this list is a dict of the form {id: int, public_ip: str}. */ -}}
-    {{- range $active_app_servers }}
-    server appserver-{{ .id }} {{ .public_ip }}:80 cookie appserver-{{ .id }} {{ if $health_check }}check{{ end }}
-    {{- end }}
-{{- end }}
-
-
 {{- /* Print config in the form of a single K/V value. */ -}}
 {{- range ls $prefix }}
   {{- with $config := .Value | parseJSON }}


### PR DESCRIPTION
This PR removes support to render old Ocim K/V format for load balancer configuration.
I'm not exactly sure how to provide simple testing instructions for this one, since there are no more old format keys in Consul, so nothing would render.

**Testing instructions:**
1. Deploy these changes on a stage load balancer (I already did this to haproxy-stage-3, so you can use that one for testing).
2. Manually add an old format key to Consul using the file provided in the ticket running:
```
consul kv import @test.json
```
3. Make sure this backend isn't rendered on `/etc/haproxy/backend.map` or `
/etc/haproxy/haproxy.cfg`.

If the files are not being rendered, run these lines:
```
rm /etc/haproxy/backend.map && consul-template -once -config /etc/consul-template/config/backend.map.hcl
rm /etc/haproxy/haproxy.cfg && consul-template -once -config /etc/consul-template/config/haproxy.cfg.hcl
```
**Reviewer:**
- [x] @Agrendalath 