### PR TITLE
SE-1463 switch to map_str to avoid wrong domain matching

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -66,7 +66,7 @@ frontend fe_https
     acl backend_fail status 500:599
     acl error_backend res.hdr(X-Maintenance) yes
     http-response redirect location /error if backend_fail !error_backend
-    use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/backend.map)]
+    use_backend %[req.hdr(host),lower,map_str(/etc/haproxy/backend.map)]
 
     # For errors raised by HAProxy redirect to /error so they will go to the error backend.
     errorloc 500 /error


### PR DESCRIPTION
We have many entries in the backend.map file, and some are subdomains of
other entries, which should map to other backends. Using the map_dom
function means that sometimes a domain is matched incorrectly. For
example, a request to `foo.sandbox.opencraft.hosting` could match a
mapping for `sandbox.opencraft.hosting` in `backend.map`, even if there
was a `foo.sandbox.opencraft.hosting` entry in the mapping.

**Testing**:

- ensure that there are separate openedx instances running where one instance has a domain which is a subdomain of another instance (eg. sandbox.opencraft.hosting and foo.sandbox.opencraft.hosting)
- verify that foo.sandbox.opencraft.hosting doesn't load (redirects to /error)
- deploy our haproxy setup using this branch (or alternatively edit live and reload haproxy since it's a one line change)
- verify that foo.sandbox.opencraft.hosting is now available.

**Author concerns**:

- switching from map_dom to map_str may have sideeffects - not sure if there was an original reason this was used.
- we do appear to exhaustively list all domains and subdomains of sandboxes, but a backwards incompatible change from of this switch would be that if `foo.bar.sandbox.opencraft.hosting` is NOT in the mapping but `bar.sandbox.opencraft.hosting` IS, and `foo.bar.sandbox.opencraft.hosting` is requested,  it will no longer have a chance of working.