### PR TITLE
[SE-1464] Set alerts for MySQL replica status

### DIFF
--- a/playbooks/group_vars/prometheus/public.yml
+++ b/playbooks/group_vars/prometheus/public.yml
@@ -19,6 +19,9 @@ prometheus_config_global_scrape_timeout: 10s
 
 prometheus_storage__tsdb__retention: 30d
 
+# without this, alertmanger won't start
+prometheus_alert_manager_cluster__advertise_address: "127.0.0.1:9093"
+
 # The defaults weren't working, though they actually should.  We are not using the Prometheus
 # consoles for now, but leaving these settings here ensures that we don't have to debug the
 # problem again once we start using them.
@@ -122,6 +125,31 @@ prometheus_rules:
       annotations:
         summary: "MySQL instance [[ $labels.node ]] ([[ $labels.instance ]]) down."
         description: "[[ $labels.node ]] ([[ $labels.instance ]]) of job [[ $labels.job ]] is down."
+    - alert: "mysql_replica_down"
+      expr: "mysql_slave_status_slave_io_running == 0 or mysql_slave_status_slave_sql_running == 0"
+      for: "10m"
+      labels:
+        severity: "critical"
+        environment: "[[ $labels.environment ]]"
+      annotations:
+        summary: "MySQL replica [[ $labels.node ]] ([[ $labels.instance ]]) replication is not running"
+        description: "[[ $labels.node ]] ([[ $labels.instance ]]) replication has been down for more than 10 minutes."
+    - alert: "mysql_replication_lag"
+      expr: "(mysql_slave_lag_seconds > 30) and on(instance) (predict_linear(mysql_slave_lag_seconds[5m], 60 * 10) > 0)"
+      for: "30m"
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "MySQL replica [[ $labels.node ]] ([[ $labels.instance ]]) is lagging"
+        description: "[[ $labels.node ]] ([[ $labels.instance ]]) replication has fallen behind for 30 minutes and is not recovering."
+    - alert: "mysql_replication_lag"
+      expr: "(mysql_heartbeat_lag_seconds > 30) and on(instance) (predict_linear(mysql_heartbeat_lag_seconds[5m], 60 * 10) > 0)"
+      for: "30m"
+      labels:
+        severity: "critical"
+      annotations:
+        summary: "MySQL replica [[ $labels.node ]] ([[ $labels.instance ]]) is lagging"
+        description: "[[ $labels.node ]] ([[ $labels.instance ]]) replication has fallen behind for 30 minutes and is not recovering."
   - name: "MongoDBRules"
     rules:
     - alert: "mongodb_down"

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -10,7 +10,7 @@ MYSQL_PROCESSES_LIMIT: 1024
 # PROMETHEUS ##################################################################
 
 MYSQL_EXPORTER_ENABLED: true
-MYSQL_EXPORTER_VERSION: 0.10.0
+MYSQL_EXPORTER_VERSION: 0.12.1
 MYSQL_EXPORTER_BASENAME: "mysqld_exporter-{{ MYSQL_EXPORTER_VERSION }}.linux-amd64"
 MYSQL_EXPORTER_BINARY: "/opt/{{ MYSQL_EXPORTER_BASENAME }}/mysqld_exporter"
 MYSQL_EXPORTER_ARCHIVE: "{{ MYSQL_EXPORTER_BASENAME }}.tar.gz"
@@ -22,7 +22,7 @@ MYSQL_EXPORTER_PASSWORD: null
 # out through the reverse proxy to actually retrieve these metrics.
 # It is uncertain whether this can actually be fixed in the exporter -- it
 # may just be a limitation of having too many databases in MySQL.
-MYSQL_EXPORTER_EXTRA_OPTS: "-collect.info_schema.tables=false -collect.info_schema.query_response_time=true"
+MYSQL_EXPORTER_EXTRA_OPTS: "--no-collect.info_schema.tables --collect.info_schema.query_response_time"
 
 MYSQL_EXPORTER_MYSQL_PASSWORD: null
 MYSQL_EXPORTER_MYSQL_USERS:

--- a/playbooks/roles/mysql/templates/mysqld_exporter.service.j2
+++ b/playbooks/roles/mysql/templates/mysqld_exporter.service.j2
@@ -3,7 +3,7 @@ Description=Prometheus MySQL Exporter
 After=network-online.target
 
 [Service]
-ExecStart={{ MYSQL_EXPORTER_BINARY }} {% if MYSQL_EXPORTER_EXTRA_OPTS != "" %}{{ MYSQL_EXPORTER_EXTRA_OPTS }}{% endif %} -web.listen-address 127.0.0.1:9104
+ExecStart={{ MYSQL_EXPORTER_BINARY }} {% if MYSQL_EXPORTER_EXTRA_OPTS != "" %}{{ MYSQL_EXPORTER_EXTRA_OPTS }}{% endif %} --web.listen-address 127.0.0.1:9104
 EnvironmentFile=/etc/mysqld_exporter.conf
 Restart=always
 RestartSec=10

--- a/playbooks/roles/prometheus/tasks/grafana.yml
+++ b/playbooks/roles/prometheus/tasks/grafana.yml
@@ -2,12 +2,12 @@
 
 - name: Grafana – add apt repository
   apt_repository:
-    repo: deb https://packagecloud.io/grafana/stable/debian/ stretch main
+    repo: deb https://packages.grafana.com/oss/deb stable main
     filename: grafana
 
 - name: Grafana – add apt key
   apt_key:
-    url: https://packagecloud.io/gpg.key
+    url: https://packages.grafana.com/gpg.key
 
 - name: Grafana – install Debian package
   apt:


### PR DESCRIPTION
**Testing instructions**

1. Load the [MySQL dashboard](https://prometheus.net.opencraft.hosting:3443/d/6-kPlS7ik/mysql?orgId=1) in Grafana. Note that both replicas are up.
1. ssh to a replica; get a `mysql` shell as root and run `STOP SLAVE;`
1. Observe in Grafana that within a few seconds, the replica is marked down
1. Note that the alert has entered a pending state [in Prometheus](https://prometheus.net.opencraft.hosting/alerts)
1. Wait ten minutes.
1. See that the alert is now firing and ops@ gets an email.
1. Run `START SLAVE;` and see that the alert resolves and dashboard returns to green

There is no easy way to test the lag alert but that's okay. . . we don't get anywhere close to enough to writes for our replicas to fall permanently behind.

![Screenshot_2019-09-18_16-34-56](https://user-images.githubusercontent.com/15718530/65187780-4ad1e380-da32-11e9-9316-f6762fcae758.png)