### PR TITLE
[SE-888] Fixes for the mattermost autolink plugin

### DIFF
--- a/playbooks/roles/mattermost/defaults/main.yml
+++ b/playbooks/roles/mattermost/defaults/main.yml
@@ -5,10 +5,6 @@ MATTERMOST_OPS_EMAIL: ops@exmaple.com
 
 MATTERMOST_VERSION: 5.8.0
 
-# UNLINK is the autolink plugin which converts JIRA tickets to clickable URL
-# https://github.com/mattermost/mattermost-plugin-autolink/releases/
-MATTERMOST_UNLINK_VERSION: 0.3.0
-
 # Restrict registration to email addresses in this domain
 MATTERMOST_RESTRICT_TO_EMAIL_DOMAIN: example.com
 

--- a/playbooks/roles/mattermost/defaults/main.yml
+++ b/playbooks/roles/mattermost/defaults/main.yml
@@ -55,7 +55,7 @@ MATTERMOST_INSTALL_TAG_FILE: "{{ MATTERMOST_STATUS_DIR }}/installation-complete"
 MATTERMOST_DOWNLOAD_URL: "https://releases.mattermost.com/{{ MATTERMOST_VERSION }}/mattermost-team-{{ MATTERMOST_VERSION }}-linux-amd64.tar.gz"
 MATTERMOST_DOWNLOAD_DEST: "/tmp/{{ MATTERMOST_DOWNLOAD_URL|basename }}"
 
-MATTERMOST_UNLINK_DOWNLOAD_URL: "https://github.com/mattermost/mattermost-plugin-autolink/releases/download/v{{ MATTERMOST_UNLINK_VERSION }}/mattermost-plugin-autolink-linux-amd64.tar.gz"
+MATTERMOST_UNLINK_DOWNLOAD_URL: "https://github.com/mattermost/mattermost-plugin-autolink/releases/download/v{{ MATTERMOST_UNLINK_VERSION }}/mattermost-autolink-{{ MATTERMOST_UNLINK_VERSION }}.tar.gz"
 MATTERMOST_UNLINK_DOWNLOAD_DEST: "/tmp/{{ MATTERMOST_UNLINK_DOWNLOAD_URL|basename }}"
 
 MATTERMOST_CONFIG_FILE: "{{ MATTERMOST_STATUS_DIR }}/config.json"

--- a/playbooks/roles/mattermost/defaults/main.yml
+++ b/playbooks/roles/mattermost/defaults/main.yml
@@ -4,6 +4,9 @@ MATTERMOST_HOSTNAME: "{{ inventory_hostname }}"
 MATTERMOST_OPS_EMAIL: ops@exmaple.com
 
 MATTERMOST_VERSION: 5.8.0
+
+# UNLINK is the autolink plugin which converts JIRA tickets to clickable URL
+# https://github.com/mattermost/mattermost-plugin-autolink/releases/
 MATTERMOST_UNLINK_VERSION: 0.3.0
 
 # Restrict registration to email addresses in this domain

--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -33,6 +33,7 @@
     force: no
 
 # This autolink configuration is NOT used UNLESS you are installing MM from scratch.
+# This is because the playbook never updates config.json on an existing installation.
 # You must MANUALLY copy it from /var/lib/mattermost/autolink.json to the correct place
 # in /var/lib/mattermost/config.json and restart MM.
 # This is explained in autolink.json.j2 but repeated here to be helpful.

--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -32,10 +32,14 @@
     group: mattermost
     force: no
 
+# This autolink configuration is NOT used UNLESS you are installing MM from scratch.
+# You must MANUALLY copy it from /var/lib/mattermost/autolink.json to the correct place
+# in /var/lib/mattermost/config.json and restart MM.
+# This is explained in autolink.json.j2 but repeated here to be helpful.
 - name: generate autolink configuration
   template:
     src: autolink.json.j2
-    dest: "{{ MATTERMOST_CONFIG_FILE|dirname }}/autolink.json"
+    dest: "{{ MATTERMOST_STATUS_DIR }}/autolink.json"
     owner: mattermost
     group: mattermost
 


### PR DESCRIPTION
This PR contains the fixes for deploying the mattermost auto-link plugin and was tested in the most-recent upgrade to 5.15.0

**Testing instructions**:
* Upgrade Mattermost using the changes in this PR and the corresponding changes in the related ansible secrets PR.
