### PR TITLE
BB-1667 Update chkrootkit expected output daily

### DIFF
--- a/playbooks/roles/common-server-init/tasks/chkrootkit.yml
+++ b/playbooks/roles/common-server-init/tasks/chkrootkit.yml
@@ -24,3 +24,11 @@
   template:
     src: 100chrootkitupdate.j2
     dest: /etc/apt/apt.conf.d/100chrootkitupdate
+
+- name: Update expected output daily
+  template:
+    src: update_chkrootkit_log
+    dest: /etc/cron.daily/update-chkrootkit-log
+    owner: root
+    group: root
+    mode: 0755

--- a/playbooks/roles/common-server-init/templates/update-chkrootkit-log
+++ b/playbooks/roles/common-server-init/templates/update-chkrootkit-log
@@ -6,4 +6,7 @@
 
 LOG_DIR=/var/log/chkrootkit
 
-cp -a -f $LOG_DIR/log.today $LOG_DIR/log.expected
+if ! diff -q $LOG_DIR/log.expected $LOG_DIR/log.today > /dev/null 2>&1; then
+    mv $LOG_DIR/log.expected $LOG_DIR/log.previous
+    cp -a -f $LOG_DIR/log.today $LOG_DIR/log.expected
+fi

--- a/playbooks/roles/common-server-init/templates/update-chkrootkit-log
+++ b/playbooks/roles/common-server-init/templates/update-chkrootkit-log
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# This script updates the expected log daily so each change is notified only
+# once.
+#
+
+LOG_DIR=/var/log/chkrootkit
+
+cp -a -f $LOG_DIR/log.today $LOG_DIR/log.expected


### PR DESCRIPTION
Description
=========

This PR adds a daily cron entry that updates the expected `chkrootkit` output with whatever was the last output.

This results in each change to the output being reported only once to ops.

Testing
----------

1. Deploy this to a VM which runs the chkrootkit daily.
2. If the vm wasn't notifying the chkrootkit diff, make sure to modify the chkrootkit expected log to make it notify.
3. Check there's no difference between the chkrootkit expected and today logs and that the vm stops notifying after one day.