### PR TITLE
[BB-1375] Update roles for deploying the pyenv environment

### DIFF
--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -64,9 +64,15 @@ OPENCRAFT_GENERATED_ENV_TOKENS:
 opencraft_all_env_tokens: "{{ OPENCRAFT_GENERATED_ENV_TOKENS | combine( OPENCRAFT_ENV_TOKENS ) }}"
 www_data_home_dir: '/var/www'
 opencraft_root_dir: '/var/www/opencraft'
-opencraft_virtualenv_dir: '/var/www/.virtualenvs/opencraft'
 opencraft_static_files_dir: '{{ opencraft_root_dir }}/build/static'
 opencraft_screenrc_path: '/home/ubuntu/ocim-screenrc'
+
+ocim_python_version: '3.6.9'
+pyenv_home: "{{ www_data_home_dir }}"
+pyenv_root: "{{ pyenv_home }}/.pyenv"
+opencraft_virtualenv_name: "opencraft"
+
+opencraft_websocket_port: 2001
 
 opencraft_nginx_static_config: |
   # serve static files
@@ -112,8 +118,3 @@ www_group: www-data
 
 # Number of months an instance is archived to have it deleted
 OPENCRAFT_DELETE_ARCHIVED_MONTHS: 12
-
-ocim_python_version: '3.6.9'
-pyenv_home: "{{ www_data_home_dir }}"
-pyenv_root: "{{ pyenv_home }}/.pyenv"
-opencraft_virtualenv_name: "opencraft"

--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -97,8 +97,8 @@ opencraft_nginx_websocket_config: |
   location /ws {
       proxy_pass http://localhost:{{ opencraft_websocket_port }}/ws;
       proxy_http_version 1.1;
-      proxy_buffering off;;
-      proxy_request_buffering off
+      proxy_buffering off;
+      proxy_request_buffering off;
       proxy_send_timeout 600s;
       proxy_read_timeout 600s;
 

--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -95,3 +95,7 @@ www_group: www-data
 
 # Number of months an instance is archived to have it deleted
 OPENCRAFT_DELETE_ARCHIVED_MONTHS: 12
+
+ocim_python_version: '3.6.9'
+pyenv_home: "{{ www_data_home_dir }}"
+pyenv_root: "{{ pyenv_home }}/.pyenv"

--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -99,3 +99,4 @@ OPENCRAFT_DELETE_ARCHIVED_MONTHS: 12
 ocim_python_version: '3.6.9'
 pyenv_home: "{{ www_data_home_dir }}"
 pyenv_root: "{{ pyenv_home }}/.pyenv"
+opencraft_virtualenv_name: "opencraft"

--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -99,13 +99,16 @@ opencraft_nginx_websocket_config: |
       proxy_http_version 1.1;
       proxy_buffering off;
       proxy_request_buffering off;
-      proxy_send_timeout 600s;
-      proxy_read_timeout 600s;
+      proxy_send_timeout 60s;
+      proxy_read_timeout 60s;
 
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
   }
 
 # The user you will log in as in an SSH session and their primary group

--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -85,6 +85,23 @@ opencraft_nginx_static_config: |
           application/javascript;
   }
 
+opencraft_nginx_websocket_config: |
+  # proxy the websocket requests to the ASGI server
+  #
+  location /ws {
+      proxy_pass http://localhost:{{ opencraft_websocket_port }}/ws;
+      proxy_http_version 1.1;
+      proxy_buffering off;;
+      proxy_request_buffering off
+      proxy_send_timeout 600s;
+      proxy_read_timeout 600s;
+
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
 # The user you will log in as in an SSH session and their primary group
 session_user: ubuntu
 session_user_group: ubuntu

--- a/playbooks/roles/ocim/files/venv_exec
+++ b/playbooks/roles/ocim/files/venv_exec
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-source "$(dirname $0)"/activate
-exec "$@"

--- a/playbooks/roles/ocim/meta/main.yml
+++ b/playbooks/roles/ocim/meta/main.yml
@@ -19,4 +19,4 @@ dependencies:
       - "{{ ocim_python_version }}"
     pyenv_virtualenv_environments:
       - python_version: "{{ ocim_python_version }}"
-        virtualenv_name: "opencraft"
+        virtualenv_name: "{{ opencraft_virtualenv_name }}"

--- a/playbooks/roles/ocim/meta/main.yml
+++ b/playbooks/roles/ocim/meta/main.yml
@@ -12,3 +12,11 @@ dependencies:
     NGINX_PROXY_READ_TIMEOUT: 600s
     NGINX_PROXY_EXTRA_CONFIG: "{{ opencraft_nginx_static_config }}"
     when: www_user != 'vagrant'
+
+  - name: pyenv
+    pyenv_home: "{{ www_data_home_dir }}"
+    pyenv_python_versions:
+      - "{{ ocim_python_version }}"
+    pyenv_virtualenv_environments:
+      - python_version: "{{ ocim_python_version }}"
+        virtualenv_name: "opencraft"

--- a/playbooks/roles/ocim/meta/main.yml
+++ b/playbooks/roles/ocim/meta/main.yml
@@ -10,7 +10,7 @@ dependencies:
     NGINX_PROXY_SERVER_NAME: "{{ OPENCRAFT_DOMAIN_NAME }}"
     NGINX_PROXY_SEND_TIMEOUT: 600s
     NGINX_PROXY_READ_TIMEOUT: 600s
-    NGINX_PROXY_EXTRA_CONFIG: "{{ opencraft_nginx_static_config }}"
+    NGINX_PROXY_EXTRA_CONFIG: "{{ opencraft_nginx_static_config + opencraft_nginx_websocket_config }}"
     when: www_user != 'vagrant'
 
   - name: pyenv

--- a/playbooks/roles/ocim/meta/main.yml
+++ b/playbooks/roles/ocim/meta/main.yml
@@ -15,6 +15,9 @@ dependencies:
 
   - name: pyenv
     pyenv_home: "{{ www_data_home_dir }}"
+    pyenv_create_pyenv_home: true
+    pyenv_user: "{{ www_user }}"
+    pyenv_group: "{{ www_group }}"
     pyenv_python_versions:
       - "{{ ocim_python_version }}"
     pyenv_virtualenv_environments:

--- a/playbooks/roles/ocim/tasks/common.yml
+++ b/playbooks/roles/ocim/tasks/common.yml
@@ -5,16 +5,11 @@
   args:
     chdir: "{{ opencraft_root_dir }}"
 
-- name: Install virtualenv
-  pip:
-    name: virtualenv
-    executable: pip3
-
-- name: Install python requirements
-  pip:
-    requirements: "{{ opencraft_root_dir }}/requirements.txt"
-    virtualenv: "{{ opencraft_virtualenv_dir }}"
-    virtualenv_python: python3.5
+- name: Install the python requirements
+  shell: |
+    . "{{ pyenv_root }}/.pyenvrc"
+    pyenv activate opencraft
+    pip install -r "{{ opencraft_root_dir }}/requirements.txt"
   become_user: "{{ www_user }}"
 
 - name: Copy archived_cleanup script

--- a/playbooks/roles/ocim/tasks/main.yml
+++ b/playbooks/roles/ocim/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: Install the venv wrapper script
   template:
     src: venv_exec.j2
-    dest: "{{ opencraft_virtualenv_dir }}/bin/exec"
+    dest: "{{ pyenv_root }}/shims/exec"
     mode: 0755
   become_user: "{{ www_user }}"
 

--- a/playbooks/roles/ocim/tasks/main.yml
+++ b/playbooks/roles/ocim/tasks/main.yml
@@ -39,8 +39,8 @@
 - import_tasks: common.yml
 
 - name: Install the venv wrapper script
-  copy:
-    src: venv_exec
+  template:
+    src: venv_exec.j2
     dest: "{{ opencraft_virtualenv_dir }}/bin/exec"
     mode: 0755
   become_user: "{{ www_user }}"

--- a/playbooks/roles/ocim/tasks/vagrant.yml
+++ b/playbooks/roles/ocim/tasks/vagrant.yml
@@ -18,8 +18,9 @@
 - name: Change directory to ~/opencraft on login
   blockinfile:
     path: ~/.bashrc
-    block:
-      . {{ opencraft_virtualenv_dir }}/bin/activate
+    marker: "# {mark} ANSIBLE MANAGED BLOCK activate_virtualenv"
+    block: |
+      pyenv activate opencraft
       cd ~/opencraft
   become_user: vagrant
 

--- a/playbooks/roles/ocim/templates/archived_cleanup.j2
+++ b/playbooks/roles/ocim/templates/archived_cleanup.j2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-. {{ pyenv_root }}.pyenvrc
+. {{ pyenv_root }}/.pyenvrc
 pyenv activate {{ opencraft_virtualenv_name }}
 cd {{ opencraft_root_dir }}
 honcho run python manage.py delete_archived -y {{ OPENCRAFT_DELETE_ARCHIVED_MONTHS }}

--- a/playbooks/roles/ocim/templates/archived_cleanup.j2
+++ b/playbooks/roles/ocim/templates/archived_cleanup.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
-source {{ opencraft_virtualenv_dir }}/bin/activate
+. {{ pyenv_root }}.pyenvrc
+pyenv activate {{ opencraft_virtualenv_name }}
 cd {{ opencraft_root_dir }}
 honcho run python manage.py delete_archived -y {{ OPENCRAFT_DELETE_ARCHIVED_MONTHS }}

--- a/playbooks/roles/ocim/templates/bashrc
+++ b/playbooks/roles/ocim/templates/bashrc
@@ -1,4 +1,5 @@
-. {{ opencraft_virtualenv_dir }}/bin/activate
+. {{ pyenv_root }}/.pyenvrc
+pyenv activate {{ opencraft_virtualenv_name }}
 
 export WORKERS={{ OPENCRAFT_WORKERS }}
 export WORKERS_LOW_PRIORITY={{ OPENCRAFT_WORKERS_LOW_PRIORITY }}

--- a/playbooks/roles/ocim/templates/venv_exec.j2
+++ b/playbooks/roles/ocim/templates/venv_exec.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+source "{{ pyenv_root }}/.pyenvrc"
+pyenv activate "{{ opencraft_virtualenv_name }}"
+exec "$@"

--- a/playbooks/roles/pyenv/defaults/main.yml
+++ b/playbooks/roles/pyenv/defaults/main.yml
@@ -1,0 +1,35 @@
+pyenv_home: "{{ ansible_env.HOME }}"
+pyenv_root: "{{ pyenv_home }}/.pyenv"
+
+pyenv_version: 'v1.2.13'
+pyenv_virtualenv_version: 'v1.1.5'
+
+
+# Takes a list of python versions to install
+pyenv_python_versions: []
+
+# Takes a list of key-value pairs of the form
+# pyenv_virtualenv_environments:
+#   - python_version: '3.6.9'
+#     virtualenv_name: 'venv'
+pyenv_virtualenv_environments: []
+
+pyenv_prerequisite_packages:
+  - make
+  - build-essential
+  - libssl-dev
+  - zlib1g-dev
+  - libbz2-dev
+  - libreadline-dev
+  - libsqlite3-dev
+  - wget
+  - curl
+  - llvm
+  - libncurses5-dev
+  - libncursesw5-dev
+  - xz-utils
+  - tk-dev
+  - libffi-dev
+  - liblzma-dev
+  - python-openssl
+  - git

--- a/playbooks/roles/pyenv/defaults/main.yml
+++ b/playbooks/roles/pyenv/defaults/main.yml
@@ -33,3 +33,8 @@ pyenv_prerequisite_packages:
   - liblzma-dev
   - python-openssl
   - git
+
+pyenv_user: 'root'
+pyenv_group: 'root'
+
+pyenv_create_pyenv_home: false

--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -4,6 +4,15 @@
     state: present
   with_items: "{{ pyenv_prerequisite_packages }}"
 
+- name: Ensure that the "{{ pyenv_home }}" directory is present and has the right permissions
+  file:
+    path: "{{ pyenv_home }}"
+    owner: "{{ pyenv_user }}"
+    group: "{{ pyenv_group }}"
+    mode: 0750
+    state: directory
+  when: pyenv_create_pyenv_home
+
 - name: Install and setup pyenv and pyenv-virtualenv
   become_user: "{{ www_user }}"
   block:
@@ -31,6 +40,7 @@
           fi
     - name: Add code to load pyenv configuration in ~/.bashrc
       blockinfile:
+        create: yes
         path: "{{ pyenv_home }}/.bashrc"
         marker: "# {mark} ANSIBLE MANAGED BLOCK load_pyenv_configuration"
         block: |

--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -1,0 +1,47 @@
+- name: Install prerequisites
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pyenv_prerequisite_packages }}"
+
+- name: Install and setup pyenv and pyenv-virtualenv
+  become_user: "{{ www_user }}"
+  block:
+    - name: Clone pyenv
+      git:
+        repo: https://github.com/pyenv/pyenv.git
+        dest: "{{ pyenv_root }}"
+        version: "{{ pyenv_version }}"
+
+    - name: Clone pyenv-virtualenv
+      git:
+        repo: https://github.com/pyenv/pyenv-virtualenv.git
+        dest: "{{ pyenv_root }}/plugins/pyenv-virtualenv"
+        version: "{{ pyenv_virtualenv_version }}"
+
+    - name: Create shell configuration for pyenv
+      blockinfile:
+        path: "{{ pyenv_root }}/.pyenvrc"
+        create: yes
+        block: |
+          export PYENV_ROOT="{{ pyenv_root }}"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          if command -v pyenv 1>/dev/null 2>&1; then
+          eval "$(pyenv init -)"
+          fi
+    - name: Add code to load pyenv configuration in ~/.bashrc
+      blockinfile:
+        path: "{{ pyenv_home }}/.bashrc"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK load_pyenv_configuration"
+        block: |
+          source "{{ pyenv_root }}/.pyenvrc"
+
+    - name: Install the requested python versions
+      shell: "{{ pyenv_root }}/bin/pyenv install -s {{ item }}"
+      with_items: "{{ pyenv_python_versions }}"
+
+    - name: Create a virtualenv environment
+      shell: |
+        . {{ pyenv_root }}/.pyenvrc
+        pyenv virtualenv -f {{ item.python_version }} {{ item.virtualenv_name }}
+      with_items: "{{ pyenv_virtualenv_environments }}"


### PR DESCRIPTION
Adds changes required to deploy a pyenv-based environment for the Ocim Vagrant development environment.

This can be used to test the changes made in https://github.com/open-craft/opencraft/pull/475/files on the vagrant devstack.
