### PR TITLE
[SE-1604] Add role to deploy a memcached server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,9 @@
 [submodule "playbooks/roles/geerlingguy.postgresql"]
 	path = playbooks/roles/geerlingguy.postgresql
 	url = https://github.com/open-craft/ansible-role-postgresql
+[submodule "playbooks/roles/geerlingguy.memcached"]
+	path = playbooks/roles/geerlingguy.memcached
+	url = https://github.com/geerlingguy/ansible-role-memcached
 [submodule "playbooks/roles/greendayonfire.mongodb"]
 	path = playbooks/roles/greendayonfire.mongodb
 	url = https://github.com/UnderGreen/ansible-role-mongodb

--- a/playbooks/deploy-all.yml
+++ b/playbooks/deploy-all.yml
@@ -15,6 +15,7 @@
 - import_playbook: postgres.yml
 - import_playbook: prometheus.yml
 - import_playbook: rabbitmq.yml
+- import_playbook: memcached.yml
 - import_playbook: relay.yml
 - import_playbook: vault.yml
 - import_playbook: wordpress.yml

--- a/playbooks/memcached.yml
+++ b/playbooks/memcached.yml
@@ -1,0 +1,15 @@
+---
+# Playbook for setting up a memcached server.
+
+- name: Set up Memcached servers
+  hosts: memcached
+  become: true
+  roles:
+    - role: common-server
+      tags: 'common-server'
+
+    - role: memcached
+      tags: 'memcached'
+
+    - role: geerlingguy.memcached
+      tags: 'geerlingguy.memcached'

--- a/playbooks/roles/memcached/README.md
+++ b/playbooks/roles/memcached/README.md
@@ -1,0 +1,11 @@
+Ansible role to prepare memcached installation
+==============================================
+
+This role complements the geerlingguy.memcached role, which installs memcached.
+It opens the right port in the firewall. No other changes are needed.
+
+Role variables
+--------------
+
+None. It uses the same variables used by the geerlingguy.memcached role.
+

--- a/playbooks/roles/memcached/tasks/main.yml
+++ b/playbooks/roles/memcached/tasks/main.yml
@@ -3,8 +3,5 @@
 - name: Open memcached port on the firewall
   ufw:
     rule: allow
-    port: "{{ item }}"
+    port: "{{ memcached_port }}"
     proto: tcp
-  with_items:
-    - "{{ memcached_port }}"
-

--- a/playbooks/roles/memcached/tasks/main.yml
+++ b/playbooks/roles/memcached/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Open memcached port on the firewall
+  ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
+  with_items:
+    - "{{ memcached_port }}"
+


### PR DESCRIPTION
This uses https://github.com/geerlingguy/ansible-role-memcached, unmodified. In the end we didn't need to add SASL authentication.
It also adds a companion role called just `memcached` which completes the setup (it just needs to open the port), same as we see in other roles.

Run this from the ansible-secrets repository, and by using the other PR (https://github.com/open-craft/ansible-secrets/pull/143). See the testing instructions there.
