### PR TITLE
BB-1667 Fix src script

### DIFF
--- a/playbooks/roles/common-server-init/tasks/chkrootkit.yml
+++ b/playbooks/roles/common-server-init/tasks/chkrootkit.yml
@@ -27,7 +27,7 @@
 
 - name: Update expected output daily
   template:
-    src: update_chkrootkit_log
+    src: update-chkrootkit-log
     dest: /etc/cron.daily/update-chkrootkit-log
     owner: root
     group: root


### PR DESCRIPTION
This fixes the script name for `update-chkrootkit-log`.

### Testing

1. Deploy any role that contains the `common-server-init` role.
1. Make sure it does not fail when copying the script.

```
$ ansible-playbook -l localhost playbooks/ocim.yml
(...)
TASK [common-server-init : Update expected output daily] ***********************
changed: [localhost]
(...)
```