### PR TITLE
Prevent corrupting HAProxy cfg with missing IPs

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -133,7 +133,7 @@ backend be-{{$config.domain_slug}}
     server unscheduled-maintenance-page 127.0.0.1:{{! maintenance_unscheduled_server_port !}}
       {{- end }}
     {{- else }}
-    server preliminary-page 149.202.180.183:80
+    server preliminary-page {{! PRELIMINARY_PAGE_SERVER_IP !}}:80
     http-request set-header Host 'default.opencraft.com'
     {{- end }}
     {{- end }}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -126,8 +126,16 @@ backend be-{{$config.domain_slug}}
     {{- /* Loop over all active appservers for this instance. */ -}}
     {{- /* Each appserver in this list is a dict of the form {id: int, public_ip: str}. */ -}}
     {{- range $config.active_app_servers }}
+      {{- if .public_ip }}
     server appserver-{{ .id }} {{ .public_ip }}:80 cookie appserver-{{ .id }} {{ if $health_check }}check{{ end }}
+      {{- else}}
+    http-response redirect location / unless { capture.req.uri / }
+    server unscheduled-maintenance-page 127.0.0.1:{{! maintenance_unscheduled_server_port !}}
+      {{- end }}
+    {{- else }}
+    server preliminary-page 149.202.180.183:80
+    http-request set-header Host 'default.opencraft.com'
     {{- end }}
-    {{- end}}
+    {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
These are a few additions to the Consul template which renders the HAProxy configuration from the values which Ocim stores in the `ocim/instances/` prefix.

Specifically, if Ocim sets the IP address to "nil" (this should never happen and yet there were entries like this for the CI tests) the unscheduled-maintenance-page will be used instead, while if there are no active appservers at all, the preliminary-page will be used.

**Testing instructions**

Grep the output of `consul kv get --recurse  ocim/instances | cut -f2- -d: | jq` on haproxy-integration.net.opencraft.hosting to find examples.

Check that those examples are properly rendered in `/etc/haproxy/haproxy.cfg` and that `/usr/sbin/haproxy -c -V -f /etc/haproxy/haproxy.cfg` is happy.