### PR TITLE
BB-1796 Install JS dependencies when provisioning Vagrant

### DIFF
--- a/playbooks/roles/ocim/tasks/vagrant.yml
+++ b/playbooks/roles/ocim/tasks/vagrant.yml
@@ -14,6 +14,7 @@
   shell: DEBIAN_FRONTEND=noninteractive make install_js_dependencies
   args:
     chdir: "{{ opencraft_root_dir }}"
+  become_user: "{{ www_user }}"
 
 - name: Install database dependencies
   shell: DEBIAN_FRONTEND=noninteractive make install_system_db_dependencies

--- a/playbooks/roles/ocim/tasks/vagrant.yml
+++ b/playbooks/roles/ocim/tasks/vagrant.yml
@@ -10,6 +10,11 @@
     force: no
   become_user: "{{ www_user }}"
 
+- name: Install javascript dependencies
+  shell: DEBIAN_FRONTEND=noninteractive make install_js_dependencies
+  args:
+    chdir: "{{ opencraft_root_dir }}"
+
 - name: Install database dependencies
   shell: DEBIAN_FRONTEND=noninteractive make install_system_db_dependencies
   args:


### PR DESCRIPTION
## Description

This PR adds a step to install JS dependencies to the OCIM Vagrant role. This is necessary to run JS tests and was added only to CI.

## Testing

1. Make sure you have an OCIM devstack that don't have the JS dependencies
2. Run `vagrant provision` with this branch checked out as `/deploy´
3. Inside the Vagrant machine run `make test.js`
4. Make sure the tests complete without errors

Alternatively, destroy the Vagrant box and run `vagrant up` which will reprovision it with the JS dependencies.