### PR TITLE
SE-1541 Add option to disable rabbitmq heartbeat

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -6,6 +6,10 @@ RABBITMQ_HTTPS_PORT: 15671
 
 RABBITMQ_HOSTNAME: "{{ inventory_hostname }}"
 
+# heartbeat is in seconds; negociated with client; set to 0 to disable server
+# side (will still be non zero if client requests.
+RABBITMQ_HEARTBEAT: 0
+
 RABBITMQ_CA_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/chain.pem"
 RABBITMQ_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/cert.pem"
 RABBITMQ_KEY_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/privkey.pem"

--- a/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2
+++ b/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2
@@ -2,6 +2,7 @@
  %% Disable SSLv3.0 (POODLE) and TLSv1.0 (BEAST) support.
  {ssl, [{versions, ['tlsv1.2', 'tlsv1.1']}]},
  {rabbit, [
+           {heartbeat, {{ RABBITMQ_HEARTBEAT }}},
            {ssl_listeners, [{{ RABBITMQ_TLS_PORT}}]},
            {ssl_options, [{cacertfile,"{{ RABBITMQ_CA_CERTIFICATE_FILE }}"},
                           {certfile,  "{{ RABBITMQ_CERTIFICATE_FILE }}"},


### PR DESCRIPTION
(disabled by default)

Self explanatory. The reason behind this change is because celery workers don't appear to be sending heartbeats even though negociating a nonzero interval, which causes regular connection resets. :(

**Test instructions**:

1. deploy rabbitmq with this branch
1. verify that the generated rabbitmq.config is valid and sets heartbeat to zero
1. see https://github.com/edx/edx-platform/pull/21567 for a practical test

**Reviewer**:

- [x] @gr4yscale 