### PR TITLE
BB-1881 Run certbot after wordpress

### DIFF
--- a/playbooks/wordpress.yml
+++ b/playbooks/wordpress.yml
@@ -25,8 +25,12 @@
   roles:
     - role: common-server
       tags: 'common-server'
+      vars:
+        # certbot must run after deploying the wordpress role
+        COMMON_SERVER_INSTALL_CERTBOT: false
 
     - geerlingguy.php-versions
     - geerlingguy.php-mysql
     - wordpress
     - tarsnap
+    - certbot


### PR DESCRIPTION
## Description

This PR makes sure the `certbot` role runs last when deploying wordpress. This ensures the nginx configurations aren't replaced to the default without SSL.

## Testing

1. Deploy `wordpress` playbook (already done)
1. Make sure `https` access work correctly