### PR TITLE
playbooks: replace deprecated with_items with loop

### DIFF
--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -2,7 +2,7 @@
   apt:
     name: "{{ item }}"
     state: present
-  with_items: "{{ pyenv_prerequisite_packages }}"
+  loop: "{{ pyenv_prerequisite_packages }}"
 
 - name: Ensure that the "{{ pyenv_home }}" directory is present and has the right permissions
   file:


### PR DESCRIPTION
Python 3.8.0 no longer parses lists in ansible roles properly: Users
were greeted with errors such as:

sre_constants.error: bad character range l-d at position 34

These mysterious errors were not present in the 3.7.x series and below.

Replacing the use of with_items: with loop: fixed the issue and the
playbook proceeded as expected.

Since use of with_* is no longer encouraged by Ansible [1], and the
unexpected behavior was exhibited by using with_items, replacement of
all instances of with_items seems the most reasonable. As with_items is
directly replacable with loop (unlike some of the other with_* items
like with_sequence), only the most ancient of Ansible versions could
run into trouble with the change.

[1] https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#migrating-from-with-x-to-loop

Fixes SE-2019


## Testing the changes

As there are no molecule tests for the roles that have been affected, the easiest way to test seems to be:

1. SSH into an Ubuntu 16.04 VM

2. Create/Activate a Python 3.8.x virtualenv

3. Install repo requirements (`pip install -r requirements.txt`)

4. Apply each role to verify no breakage.