### PR TITLE
load-balancer-v2: add certs dir to stats ssl

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -78,7 +78,7 @@ frontend fe_https
 
 {% if haproxy_enable_stats_page %}
 frontend stats
-    bind *:{{! haproxy_stats_port !}} ssl crt /etc/haproxy/certs.pem
+    bind *:{{! haproxy_stats_port !}} ssl crt /etc/haproxy/certs.pem crt /etc/haproxy/certs
     stats enable
     stats uri /stats
     stats refresh 10s


### PR DESCRIPTION
The stats page is only using certificates from certs.pem while the
correct certificate is under /etc/haproxy/certs/

This would result in invalid cert errors.

Fixes SE-2016