### PR TITLE
[BB-2052] Fix a bug ignoring the 1st certificate when rendering certificates

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/consul-certificates-render.sh
+++ b/playbooks/roles/load-balancer-v2/templates/consul-certificates-render.sh
@@ -2,4 +2,4 @@
 
 consul watch -type=keyprefix -prefix={{ haproxy_consul_certs_prefix }} \
     consul lock {{ haproxy_consul_lock_prefix }} \
-        'rm -f /etc/haproxy/certs/ocim/* && consul kv get -keys {{ haproxy_consul_certs_prefix }}/ | { read -r; while read -r key; do consul kv get "$key" > "/etc/haproxy/certs/ocim/${key##*/}"; done; } && flock -n -E 0 /tmp/haproxy-reload-lock service haproxy reload'
+        'rm -f /etc/haproxy/certs/ocim/* && consul kv get -keys {{ haproxy_consul_certs_prefix }}/ | { while read -r key; do consul kv get "$key" > "/etc/haproxy/certs/ocim/${key##*/}"; done; } && flock -n -E 0 /tmp/haproxy-reload-lock service haproxy reload'


### PR DESCRIPTION
The code to ignore the first line in the output of the consul command
to get the keys was added because there was an empty 'ocim/certs/' key
in the staging environment where this was tested. But the key wasn't
present in the production environment, thereby causing the first
certificate to be ignored. This fix will work in the stage environment
after removing the empty key there.