### PR TITLE
[BB-2052] Add a separate deploy hook script for deploying certificates to Consul

### DIFF
--- a/playbooks/roles/cert-manager/tasks/main.yml
+++ b/playbooks/roles/cert-manager/tasks/main.yml
@@ -32,6 +32,12 @@
       dest: "/lib/systemd/system/cert-manager.service"
       mode: "0644"
 
+- name: Copy the deploy_cert.sh script template
+  template:
+    src: "deploy_cert.sh"
+    dest: "/usr/local/sbin/deploy_cert.sh"
+    mode: "0755"
+
 - name: Enable and start the cert-manager service
   systemd:
     daemon_reload: yes

--- a/playbooks/roles/cert-manager/templates/deploy_cert.sh
+++ b/playbooks/roles/cert-manager/templates/deploy_cert.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script is invoked by certbot after a certificate has been successfully provisioned or has been
+# renewed successfully.
+
+cd {{ cert_manager_path }}
+
+pipenv run python ./deploy_cert.py --log-level '{{ cert_manager_log_level }}' --consul-certs-prefix '{{ cert_manager_consul_certs_prefix }}'


### PR DESCRIPTION
This is needed because the provisioning is done by the certbot
installed inside the cert-manager's pipenv environment and the renewal
is handled by the systemd timer which uses the system-wide
installation of certbot. This script explicitly navigates to the
cert-manager directory and runs the hook script using 'pipenv run'.

**Testing instructions**:
* Deploy the changes in this PR on stage and verify that a well-formed `deploy_cert.sh` script is created under `/usr/local/sbin`.
* Deploy the corresponding changes in the `cert-manager` PR which set the deploy hook to the script added here.
* Restart the `cert-manager` service.
* Verify that for a new instance, the certificate is provisioned without any errors once the DNS record is created and the changes have propagated.
* Run a force-renewal for the certificate provisioned in the previous step from outside the `cert-manager` pipenv environment and verify that the certificate is renewed and the deploy hook is called without any issue.