### PR TITLE
[BB-2121] Redirect HTTP requests to HTTPS in Nginx configuration file

### DIFF
--- a/playbooks/roles/wordpress/tasks/nginx.yml
+++ b/playbooks/roles/wordpress/tasks/nginx.yml
@@ -8,15 +8,6 @@
     - 80
     - 443
 
-- name: mount /var/www
-  mount: name=/var/www src=/dev/vdb1 fstype=ext4 state=mounted
-
-- name: chown www-data /var/www
-  file: path=/var/www mode=750 owner=www-data group=www-data state=directory
-
-- name: mkdir /var/www/log
-  file: path=/var/www/log mode=750 state=directory
-
 - name: Copy nginx global configuration
   synchronize: src="global/" dest=/etc/nginx/global checksum=yes delete=yes owner=no group=no
 

--- a/playbooks/roles/wordpress/templates/default-nginx.j2
+++ b/playbooks/roles/wordpress/templates/default-nginx.j2
@@ -8,8 +8,9 @@ server {
 # HTTPS
 server {
         listen 443 ssl;
-        ssl_certificate /etc/ssl/certs/{{ DEFAULT_SITE_HOSTNAME }}.crt;
-        ssl_certificate_key /etc/ssl/private/{{ DEFAULT_SITE_HOSTNAME }}.key;
+        server_name {{ DEFAULT_SITE_HOSTNAME }};
+        ssl_certificate /etc/letsencrypt/live/{{ DEFAULT_SITE_HOSTNAME }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ DEFAULT_SITE_HOSTNAME }}/privkey.pem;
 
 	root /var/www/{{ DEFAULT_SITE_HOSTNAME }};
 	index index.html index.php;

--- a/playbooks/roles/wordpress/templates/default-nginx.j2
+++ b/playbooks/roles/wordpress/templates/default-nginx.j2
@@ -1,6 +1,15 @@
+# HTTP
 server {
 	listen *:80;
 	server_name {{ DEFAULT_SITE_HOSTNAME }};
+	return 301 https://$host$request_uri;
+}
+
+# HTTPS
+server {
+        listen 443 ssl;
+        ssl_certificate /etc/ssl/certs/{{ DEFAULT_SITE_HOSTNAME }}.crt;
+        ssl_certificate_key /etc/ssl/private/{{ DEFAULT_SITE_HOSTNAME }}.key;
 
 	root /var/www/{{ DEFAULT_SITE_HOSTNAME }};
 	index index.html index.php;

--- a/playbooks/roles/wordpress/templates/maintenance-nginx.j2
+++ b/playbooks/roles/wordpress/templates/maintenance-nginx.j2
@@ -1,6 +1,15 @@
+# HTTP
 server {
 	listen *:80;
         server_name {{ MAINTENANCE_SITE_HOSTNAME }};
+        return 301 https://$host$request_uri;
+}
+
+# HTTPS
+server{
+        listen 443 ssl;
+        ssl_certificate /etc/ssl/certs/{{ MAINTENANCE_SITE_HOSTNAME }}.crt;
+        ssl_certificate_key /etc/ssl/private/{{ MAINTENANCE_SITE_HOSTNAME }}.key;
 
 	root /var/www/{{ MAINTENANCE_SITE_HOSTNAME }};
 	index index.html index.php;

--- a/playbooks/roles/wordpress/templates/maintenance-nginx.j2
+++ b/playbooks/roles/wordpress/templates/maintenance-nginx.j2
@@ -8,8 +8,9 @@ server {
 # HTTPS
 server{
         listen 443 ssl;
-        ssl_certificate /etc/ssl/certs/{{ MAINTENANCE_SITE_HOSTNAME }}.crt;
-        ssl_certificate_key /etc/ssl/private/{{ MAINTENANCE_SITE_HOSTNAME }}.key;
+        server_name {{ MAINTENANCE_SITE_HOSTNAME }};
+        ssl_certificate /etc/letsencrypt/live/{{ MAINTENANCE_SITE_HOSTNAME }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ MAINTENANCE_SITE_HOSTNAME }}/privkey.pem;
 
 	root /var/www/{{ MAINTENANCE_SITE_HOSTNAME }};
 	index index.html index.php;

--- a/playbooks/roles/wordpress/templates/wordpress-nginx.j2
+++ b/playbooks/roles/wordpress/templates/wordpress-nginx.j2
@@ -8,8 +8,9 @@ server {
 # HTTPS
 server {
         listen 443 ssl;
-        ssl_certificate /etc/ssl/certs/{{ LANDING_SITE_HOSTNAME }}.crt;
-        ssl_certificate_key /etc/ssl/private/{{ LANDING_SITE_HOSTNAME }}.key;
+        server_name {{ LANDING_SITE_HOSTNAME }} www.{{ LANDING_SITE_HOSTNAME }};
+        ssl_certificate /etc/letsencrypt/live/{{ LANDING_SITE_HOSTNAME }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ LANDING_SITE_HOSTNAME }}/privkey.pem;
 
         {{ NGINX_REWRITES }}
 

--- a/playbooks/roles/wordpress/templates/wordpress-nginx.j2
+++ b/playbooks/roles/wordpress/templates/wordpress-nginx.j2
@@ -1,6 +1,15 @@
+# HTTP
 server {
         listen *:80;
         server_name {{ LANDING_SITE_HOSTNAME }} www.{{ LANDING_SITE_HOSTNAME }};
+        return 301 https://$host$request_uri;
+}
+
+# HTTPS
+server {
+        listen 443 ssl;
+        ssl_certificate /etc/ssl/certs/{{ LANDING_SITE_HOSTNAME }}.crt;
+        ssl_certificate_key /etc/ssl/private/{{ LANDING_SITE_HOSTNAME }}.key;
 
         {{ NGINX_REWRITES }}
 

--- a/playbooks/wordpress.yml
+++ b/playbooks/wordpress.yml
@@ -22,15 +22,21 @@
       - php7.3-imap
       - php7.3-json
     - php_mysql_package: php7.3-mysql
+  pre_tasks:
+
+    - name: mount /var/www
+      mount: name=/var/www src=/dev/vdb1 fstype=ext4 state=mounted
+
+    - name: chown www-data /var/www
+      file: path=/var/www mode=750 owner=www-data group=www-data state=directory
+
+    - name: mkdir /var/www/log
+      file: path=/var/www/log mode=750 state=directory
+
   roles:
     - role: common-server
       tags: 'common-server'
-      vars:
-        # certbot must run after deploying the wordpress role
-        COMMON_SERVER_INSTALL_CERTBOT: false
-
     - geerlingguy.php-versions
     - geerlingguy.php-mysql
     - wordpress
     - tarsnap
-    - certbot


### PR DESCRIPTION
Work in Progress

- As I don't have access to the ansible-secrets repository, I'm not able to test the changes in the wordpress Ansible playbook. I have tested the solution in a separate Nginx webserver, installed from scratch, and it worked.

- TODO: create the corresponding SSL certificates and add them to ansible-secrets