### PR TITLE
[ARCHIVE] SE-2197: add an `apticron` role

### DIFF
--- a/playbooks/ocim-vagrant.yml
+++ b/playbooks/ocim-vagrant.yml
@@ -20,3 +20,8 @@
     - import_role:
         name: ocim
         tasks_from: vagrant
+
+  roles:
+    - name: apticron
+      tags:
+        - apticron

--- a/playbooks/ocim-vagrant.yml
+++ b/playbooks/ocim-vagrant.yml
@@ -25,3 +25,5 @@
     - name: apticron
       tags:
         - apticron
+      email_to: kahlil@opencraft.com
+      email_from: apticron@ocim.vagrant.localdomain

--- a/playbooks/roles/apticron/defaults/main.yml
+++ b/playbooks/roles/apticron/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 
-# Send email alerts here
+# Send email alerts To this address
 email_to: ops@opencraft.com 
+
+# Email alerts are sent From this address
+email_from: "apticron@{{ ansible_hostname }}"

--- a/playbooks/roles/apticron/defaults/main.yml
+++ b/playbooks/roles/apticron/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Send email alerts here
+email_to: ops@opencraft.com 

--- a/playbooks/roles/apticron/tasks/main.yml
+++ b/playbooks/roles/apticron/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: apticron package is installed
+  apt:
+    name: apticron
+
+- name: apticron is configured
+  template:
+    src: apticron.conf.j2
+    dest: /etc/apticron/apticron.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/playbooks/roles/apticron/templates/apticron.conf.j2
+++ b/playbooks/roles/apticron/templates/apticron.conf.j2
@@ -36,7 +36,8 @@ EMAIL="{{ email_to }}"
 # of "hostname -f" for the system name in the mails it generates. This option
 # overrides the ALL_FQDNS above.
 #
-# XXX Consider using the ansible name.
+# XXX If you are having trouble with the system names returned by `hostname -f`,
+# consider using the hostname used by the ansible inventory.
 # SYSTEM="{{ inventory_hostname }}"
 
 #

--- a/playbooks/roles/apticron/templates/apticron.conf.j2
+++ b/playbooks/roles/apticron/templates/apticron.conf.j2
@@ -99,4 +99,4 @@ EMAIL="{{ email_to }}"
 # 'From:' field used in the notification e-mails. Your default sender will
 # be something like root@ubuntu1604.localdomain.
 #
-# CUSTOM_FROM=""
+CUSTOM_FROM="{{ email_from }}"

--- a/playbooks/roles/apticron/templates/apticron.conf.j2
+++ b/playbooks/roles/apticron/templates/apticron.conf.j2
@@ -59,7 +59,7 @@ EMAIL="{{ email_to }}"
 # packages on hold in your system. The default behavior is downloading and
 # listing them as any other package.
 #
-# NOTIFY_HOLDS="0"
+NOTIFY_HOLDS="0"
 
 #
 # Set NOTIFY_NEW="0" if you don't want to be notified about packages which
@@ -70,13 +70,13 @@ EMAIL="{{ email_to }}"
 # so they will be listed in dist-upgrade output. Please take a look at
 # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=531002#44
 #
-# NOTIFY_NEW="0"
+NOTIFY_NEW="0"
 
 #
 # Set NOTIFY_NO_UPDATES="0" if you don't want to be notified when there is no
 # new versions. Set to 1 could assure you that apticron works well.
 #
-# NOTIFY_NO_UPDATES="0"
+NOTIFY_NO_UPDATES="0"
 
 #
 # Set CUSTOM_SUBJECT if you want to replace the default subject used in

--- a/playbooks/roles/apticron/templates/apticron.conf.j2
+++ b/playbooks/roles/apticron/templates/apticron.conf.j2
@@ -1,0 +1,101 @@
+# apticron.conf
+#
+# set EMAIL to a space separated list of addresses which will be notified of
+# impending updates
+#
+EMAIL="{{ email_to }}"
+
+#
+# Set DIFF_ONLY to "1" to only output the difference of the current run
+# compared to the last run (ie. only new upgrades since the last run). If there
+# are no differences, no output/email will be generated. By default, apticron
+# will output everything that needs to be upgraded.
+#
+# DIFF_ONLY="1"
+
+#
+# Set LISTCHANGES_PROFILE if you would like apticron to invoke apt-listchanges
+# with the --profile option. You should add a corresponding profile to
+# /etc/apt/listchanges.conf
+#
+# LISTCHANGES_PROFILE="apticron"
+
+#
+# From hostname manpage: "Displays  all FQDNs of the machine. This option
+# enumerates all configured network addresses on all configured network inter‐
+# faces, and translates them to DNS domain names. Addresses that cannot be
+# translated (i.e. because they do not have an appro‐ priate  reverse DNS
+# entry) are skipped. Note that different addresses may resolve to the same
+# name, therefore the output may contain duplicate entries. Do not make any
+# assumptions about the order of the output."
+#
+# ALL_FQDNS="1"
+
+#
+# Set SYSTEM if you would like apticron to use something other than the output
+# of "hostname -f" for the system name in the mails it generates. This option
+# overrides the ALL_FQDNS above.
+#
+# XXX Consider using the ansible name.
+# SYSTEM="{{ inventory_hostname }}"
+
+#
+# Set IPADDRESSNUM if you would like to configure the maximal number of IP
+# addresses apticron displays. The default is to display 1 address of each
+# family type (inet, inet6), if available.
+#
+# IPADDRESSNUM="1"
+
+#
+# Set IPADDRESSES to a whitespace separated list of reachable addresses for
+# this system. By default, apticron will try to work these out using the
+# "ip" command
+#
+# IPADDRESSES="192.0.2.1 2001:db8:1:2:3::1"
+
+#
+# Set NOTIFY_HOLDS="0" if you don't want to be notified about new versions of
+# packages on hold in your system. The default behavior is downloading and
+# listing them as any other package.
+#
+# NOTIFY_HOLDS="0"
+
+#
+# Set NOTIFY_NEW="0" if you don't want to be notified about packages which
+# are not installed in your system. Yes, it's possible! There are some issues
+# related to systems which have mixed stable/unstable sources. In these cases
+# apt-get will consider for example that packages with "Priority:
+# required"/"Essential: yes" in unstable but not in stable should be installed,
+# so they will be listed in dist-upgrade output. Please take a look at
+# http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=531002#44
+#
+# NOTIFY_NEW="0"
+
+#
+# Set NOTIFY_NO_UPDATES="0" if you don't want to be notified when there is no
+# new versions. Set to 1 could assure you that apticron works well.
+#
+# NOTIFY_NO_UPDATES="0"
+
+#
+# Set CUSTOM_SUBJECT if you want to replace the default subject used in
+# the notification e-mails. This may help filtering/sorting client-side e-mail.
+# If you want to use internal vars please use single quotes here. Ex:
+# $CUSTOM_SUBJECT='[apticron] $SYSTEM: $NUM_PACKAGES package update(s)'
+#
+# CUSTOM_SUBJECT=""
+
+# Set CUSTOM_NO_UPDATES_SUBJECT if you want to replace the default subject used
+# in the no update notification e-mails. This may help filtering/sorting
+# client-side e-mail.
+# If you want to use internal vars please use single quotes here. Ex:
+# $CUSTOM_NO_UPDATES_SUBJECT='[apticron] $SYSTEM: no updates'
+#
+# CUSTOM_NO_UPDATES_SUBJECT=""
+
+#
+# Set CUSTOM_FROM if you want to replace the default sender by changing the
+# 'From:' field used in the notification e-mails. Your default sender will
+# be something like root@ubuntu1604.localdomain.
+#
+# CUSTOM_FROM=""


### PR DESCRIPTION
**Keep this PR in case we need it at some time in the future, even though we don't want to merge it right now.**

Adds a role to install and configure apticron role.  

This role takes an optional 'email_to' parameter which defaults to 'ops@opencraft.com'.

Considering using `inventory_hostname` rather than relying on `hostname -f` for the host name identification in the report. Please let me know if you think this is a good idea.

**Jira tickets:** SE-2197

**Testing instructions:**

You can test this from your OCIM vagrant devstack.
I've added the role to the `ocim-vagrant.yml` playbook for testing/review, so you can 
```
ANSIBLE_INVENTORY=.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
ansible-playbook deploy/playbooks/ocim-vagrant.yml -t apticron
```
We can role that back before merging and perhaps add the role to `ocim` and `cert-manger` playbooks.

**Reviewers**
- [ ] @swalladge 
- [ ] @lgp171188 