### PR TITLE
[SE-2530]+[SE-2435] Add Consul ACL tokens to config

### DIFF
--- a/playbooks/roles/consul/defaults/main.yml
+++ b/playbooks/roles/consul/defaults/main.yml
@@ -29,6 +29,8 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 consul_acl_master_token: null
 consul_acl_default_policy: allow
 consul_acl_down_policy: extend-cache
+# TODO: Deprecated in Consul 1.4.0: https://www.consul.io/docs/agent/options.html#acl_token_legacy
+consul_acl_token: null
 
 # Example:
 #

--- a/playbooks/roles/consul/templates/config.json.j2
+++ b/playbooks/roles/consul/templates/config.json.j2
@@ -18,6 +18,9 @@
     "acl_default_policy": "{{ consul_acl_default_policy }}",
     "acl_master_token": "{{ consul_acl_master_token }}",
 {% endif %}
+{% if consul_acl_token %}
+    "acl_token": "{{ consul_acl_token }}",
+{% endif %}
 {% endif %}
 {% if consul_server %}
     "bootstrap_expect": {{ consul_servers | length }},


### PR DESCRIPTION
This adds `acl_token` to generated Consul agent config.

If we don't have an `acl_master_token`, consul will use the anonymous access (independently of whether there's a master token defined).
Since we want to move to token-based connections, we need to specify the token to use.

Notes:
- there seems to be no problem in having an `acl_token` together with `acl_master_token`. Consul will use the `acl_token` token in operations like `consul kv get -keys /`
- *this PR should be merged after all policies are correctly defined* See the [accompanying PR](https://github.com/open-craft/ansible-secrets/pull/178/files). Otherwise we'd be asking servers to use policies that don't exist or that aren't complete

Testing:
- apply it with ansible, or check that the ansible code is in the right place
- check that adding the `acl_token` line in `config.json` has an effect
- to do that, change the line in a stage server to an UUID4 you choose, and use `systemctl restart consul`. `journalctl -u consul.service -xef` will complain that there's no ACL; that means it has an effect
- then you can create an ACL (e.g. at https://ourconsulstageURL…:18500/ui/dc1/acls, after using the management token), for the UUID that you choose, and granting or denying some access (see consul docs)
