### PR TITLE
Introduce cert-manager watch delay.

### DIFF
--- a/playbooks/roles/cert-manager/defaults/main.yml
+++ b/playbooks/roles/cert-manager/defaults/main.yml
@@ -13,3 +13,6 @@ cert_manager_consul_ocim_prefix: "ocim/instances"
 cert_manager_consul_certs_prefix: "ocim/certs"
 cert_manager_consul_watch_prefix: "ocim/instances"
 cert_manager_consul_lock_prefix: "lock/ocim"
+
+cert_manager_watch_delay: 120
+cert_manager_dns_delay: 60

--- a/playbooks/roles/cert-manager/templates/cert-manager.sh
+++ b/playbooks/roles/cert-manager/templates/cert-manager.sh
@@ -11,10 +11,12 @@
 cd {{ cert_manager_path }}
 
 consul watch -type=keyprefix -prefix={{ cert_manager_consul_watch_prefix }} \
-    consul lock {{ cert_manager_consul_lock_prefix }} \
-        pipenv run python manage_certs.py {% if cert_manager_stage %}--letsencrypt-use-staging{% endif %} \
-            --contact-email {{ cert_manager_email }} \
-            --log-level {{ cert_manager_log_level }} \
-            --webroot-path {{ cert_manager_webroot_path }} \
-            --consul-ocim-prefix {{ cert_manager_consul_ocim_prefix }} \
-            --consul-certs-prefix {{ cert_manager_consul_certs_prefix }}
+    "sleep {{ cert_manager_watch_delay }}; \
+     consul lock {{ cert_manager_consul_lock_prefix }} \
+         pipenv run python manage_certs.py {% if cert_manager_stage %}--letsencrypt-use-staging{% endif %} \
+             --contact-email {{ cert_manager_email }} \
+             --log-level {{ cert_manager_log_level }} \
+             --webroot-path {{ cert_manager_webroot_path }} \
+             --consul-ocim-prefix {{ cert_manager_consul_ocim_prefix }} \
+             --consul-certs-prefix {{ cert_manager_consul_certs_prefix }} \
+             --dns-delay {{ cert_manager_dns_delay }}"


### PR DESCRIPTION
The cert-manager should not request certificate right away when DNS records for an instance are set. Instead it should wait some time for the DNS changes to propagate.

This introduces two delays:
1. Make the script that watches for Ocim instance updates in consul sleep for 2 minutes before running the script which acquires a lock requests new certificates. This sleep is required to give Gandi some time to update the DNS records so that when cert-manager requests the certificates, the DNS records are already in place and working correctly.
2. Pass a `--dns-delay` parameter to cert-manager so that it only requests certificates for domains which have been updated more than that `dns_delay` seconds ago. This delay is required so that when cert-manager is invoked after the 2 minute sleep, it doesn't try to request certificates for instances that were potentially created/updated during the sleep.

This PR is part of [SE-2431](https://tasks.opencraft.com/browse/SE-2431) which also includes:
- https://github.com/open-craft/opencraft/pull/562
- https://github.com/open-craft/cert-manager/pull/13

**Author notes and concerns**:

No idea whether the timeout values  of 1 and 2 minutes are appropriate. We might have to tweak them once we see how they work in practice.