### PR TITLE
[BB-2278] Implement changes to allow consul auto configuration on AWS

### DIFF
--- a/playbooks/roles/consul/README.md
+++ b/playbooks/roles/consul/README.md
@@ -1,27 +1,31 @@
 # Ansible Role for Consul
 
-Description N/A
-
-## Requirements
-
-N/A
+This role installs and sets up Consul to connect to a Consul cluster.
 
 ## Role Variables
 
-N/A
+See `defaults/main.yml`.
 
 ## Dependencies
 
-None.
+This depends on the 'nginx-proxy' role in the same repository.
 
-## Example Playbook
+## Usage
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+This role usually requires the `consul_ip`, `consul_nodename` variables to be set for each host. However, in AWS,
+when EC2 instances are launched from an AMI or stopped and started, or use an elastic IP, their IP addresses will
+likely change. So to allow automatic configuration of the `consul_ip`, `consul_nodename` variables
+while generating the consul configuration, the `consul_auto_generate_config` flag can be set to a
+truthy value.
 
-    - hosts: servers
-      roles:
-        - consul
+When `consul_auto_generate_config` is set to a truthy value, a script which wraps the consul startup command is
+set up in the consul services. It determines the EC2 instance's IP addresses (private and public) and
+automatically generates the consul configuration file with the correct IP address and an appropriate,
+unique node name.
 
-## License
+The unique name is generated as '<value of consul_nodename>-<private IP address>-<public IP address>', where
+the '.' in the IP address values are replaced by '-'. After generating the correct configuration, the wrapper script
+starts consul.
 
-AGPLv3
+If the node was already in the cluster before and its IP address or node name has changed, the wrapper script
+also cleans up the stale `node-id` file and allows the node to join the cluster as a new node.

--- a/playbooks/roles/consul/README.md
+++ b/playbooks/roles/consul/README.md
@@ -29,3 +29,8 @@ starts consul.
 
 If the node was already in the cluster before and its IP address or node name has changed, the wrapper script
 also cleans up the stale `node-id` file and allows the node to join the cluster as a new node.
+
+Note that the automatic consul reconfiguration works only at the service startup time. So if an elastic IP address
+was assigned/unassigned to an EC2 instance, the consul configuration will not be automatically updated till the
+service is manually restarted. If the service is not restarted, this will cause the consul cluster to think that
+the node is down as the old public IP address is still registered there and is now unreachable.

--- a/playbooks/roles/consul/README.md
+++ b/playbooks/roles/consul/README.md
@@ -2,6 +2,10 @@
 
 This role installs and sets up Consul to connect to a Consul cluster.
 
+## License
+
+AGPLv3
+
 ## Role Variables
 
 See `defaults/main.yml`.

--- a/playbooks/roles/consul/defaults/main.yml
+++ b/playbooks/roles/consul/defaults/main.yml
@@ -9,6 +9,11 @@ consul_server: false
 consul_ui: false
 consul_backup: false
 
+# Allows automatically generating the consul configuration of an AWS EC2 instance
+# based on its private and public IP addresses. Note that this only works on AWS and
+# a service (re)start is required to apply the configuration changes.
+consul_auto_generate_config: false
+
 consul_bin_dir: "/usr/local/bin"
 consul_config_dir: "/etc/consul"
 consul_data_dir: "/var/lib/consul"

--- a/playbooks/roles/consul/tasks/main.yml
+++ b/playbooks/roles/consul/tasks/main.yml
@@ -61,6 +61,26 @@
   when: consul_service_config != ""
   notify: restart consul
 
+- name: Set up consul automatic configuration generation
+  block:
+    - name: Copy the wrapper script files
+      template:
+        src: "{{ item }}"
+        dest: "/usr/local/sbin/{{ item }}"
+        owner: root
+        group: root
+        mode: '755'
+      with_items:
+        - run_consul.sh.j2
+        - update_consul_config.py.j2
+
+    - name: Ensure that the consul configuration file is group-writeable
+      file:
+        path: "{{ consul_config_dir }}/config.json"
+        mode: g+w
+
+  when: consul_auto_generate_config
+
 - name: Create Consul systemd service file
   template:
     src: consul.service.j2

--- a/playbooks/roles/consul/tasks/main.yml
+++ b/playbooks/roles/consul/tasks/main.yml
@@ -65,14 +65,14 @@
   block:
     - name: Copy the wrapper script files
       template:
-        src: "{{ item }}"
+        src: "{{ item }}.j2"
         dest: "/usr/local/sbin/{{ item }}"
         owner: root
         group: root
         mode: '755'
       with_items:
-        - run_consul.sh.j2
-        - update_consul_config.py.j2
+        - run_consul.sh
+        - update_consul_config.py
 
     - name: Ensure that the consul configuration file is group-writeable
       file:

--- a/playbooks/roles/consul/templates/consul.service.j2
+++ b/playbooks/roles/consul/templates/consul.service.j2
@@ -7,7 +7,11 @@ After=network-online.target
 User=consul
 Group=consul
 PermissionsStartOnly=true
+{% if consul_auto_generate_config %}
+ExecStart=/usr/local/sbin/run_consul.sh
+{% else %}
 ExecStart={{ consul_bin_dir }}/consul agent -config-dir {{ consul_config_dir }}
+{% endif %}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 Restart=always

--- a/playbooks/roles/consul/templates/run_consul.sh.j2
+++ b/playbooks/roles/consul/templates/run_consul.sh.j2
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PYTHONUNBUFFERED=1 /usr/bin/python3 /usr/local/sbin/update_consul_config.py
+
+if [ $? -eq 0 ]; then
+    {{ consul_bin_dir }}/consul agent -config-dir {{ consul_config_dir }}
+else
+    echo "Unable to update consul configuration. Exiting." >&2
+fi

--- a/playbooks/roles/consul/templates/update_consul_config.py.j2
+++ b/playbooks/roles/consul/templates/update_consul_config.py.j2
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+import json
+import logging
+import os
+import urllib.request
+
+
+logging.basicConfig(
+    level='INFO',
+    format='%(asctime)s %(message)s',
+    handlers=[logging.StreamHandler()],
+)
+
+
+def get_private_ip_address():
+    """
+    Return the EC2 instance's private IP address from the metadata service.
+    """
+    return urllib.request.urlopen('http://169.254.169.254/latest/meta-data/local-ipv4').read().decode()
+
+
+def get_public_ip_address():
+    """
+    Return the EC2 instance's public IP address from the metadata service.
+    """
+    return urllib.request.urlopen('http://169.254.169.254/latest/meta-data/public-ipv4').read().decode()
+
+
+def main():
+    """
+    Check the current configuration file and generate a new configuration file if needed.
+    """
+    generate_new_config = False
+    with open('/etc/consul.d/config.json') as consul_config_file:
+        consul_config = json.load(consul_config_file)
+        advertise_address = consul_config['advertise_addr']
+        node_name = consul_config['node_name']
+        data_dir = consul_config['data_dir']
+        private_ip_address = get_private_ip_address()
+        public_ip_address = get_public_ip_address()
+        node_name_prefix = "{{ consul_nodename }}"
+        generated_node_name = '{}-{}-{}'.format(
+            node_name_prefix,
+            private_ip_address.replace('.', '-'),
+            public_ip_address.replace('.', '-'),
+        )
+        if (public_ip_address != advertise_address or
+                generated_node_name != node_name):
+            logging.info(
+                'Detected changes. Generating a new config file.'
+            )
+            generate_new_config = True
+
+    if generate_new_config:
+        consul_config.update(
+            {
+                'advertise_addr': public_ip_address,
+                'node_name': generated_node_name,
+            }
+        )
+        with open('/etc/consul.d/config.json', 'w') as new_consul_config_file:
+                    json.dump(consul_config, new_consul_config_file)
+
+        node_id_file = os.path.join(data_dir, 'node-id')
+        if (os.path.exists(node_id_file) and os.path.isfile(node_id_file)):
+            # Removing the existing node-id file is necessary when the node name changes. Otherwise
+            # consul complains about a duplicate node id.
+            logging.info('Existing node-id file found. Removing it')
+            os.remove(node_id_file)
+    else:
+        logging.info('No changes detected. Using the existing config file.')
+
+
+if __name__ == '__main__':
+    main()

--- a/playbooks/roles/consul/templates/update_consul_config.py.j2
+++ b/playbooks/roles/consul/templates/update_consul_config.py.j2
@@ -32,7 +32,7 @@ def main():
     Check the current configuration file and generate a new configuration file if needed.
     """
     generate_new_config = False
-    with open('/etc/consul.d/config.json') as consul_config_file:
+    with open('{{ consul_config_dir }}/config.json') as consul_config_file:
         consul_config = json.load(consul_config_file)
         advertise_address = consul_config['advertise_addr']
         node_name = consul_config['node_name']
@@ -59,7 +59,7 @@ def main():
                 'node_name': generated_node_name,
             }
         )
-        with open('/etc/consul.d/config.json', 'w') as new_consul_config_file:
+        with open('{{ consul_config_dir }}/config.json', 'w') as new_consul_config_file:
                     json.dump(consul_config, new_consul_config_file)
 
         node_id_file = os.path.join(data_dir, 'node-id')


### PR DESCRIPTION
This PR implements the changes to allow automatic generation of consul configuration at service startup time when the `consul_auto_generate_config` flag is set to a truthy value.

**Testing instructions**:
* Spawn an EC2 instance and run the sidecar playbook with the `consul_auto_generate_config` flag set to `true` in the `hosts` file.
* Verify that the playbook finishes successfully. Log in to the EC2 instance and verify that the auto-generated consul configuration file, `/etc/consul/config.json` uses the correct public IP address as the value of the `advertise_addr` parameter and that the `node_name` parameter is set to the format `<consul_nodename>-<private IP address separated by - instead .>-<public IP address separated by - . instead of .>`.
- Verify that the systemd service unit file `/etc/systemd/system/consul.service` uses the wrapper script `/usr/local/sbin/run_consul.sh` instead of the default `https://github.com/open-craft/ansible-playbooks/pull/new/guruprasad/BB-2278-autodetect-consul-configuration`.
- Verify that the `run_script.sh` script and `update_consul_config.py` scripts are copied to `/usr/local/sbin` directory.
* Check the logs of the consul service for any errors by running `sudo journalctl -f -u consul.service`.
* Run `consul members` on the instance to verify that it is added to the cluster. Verify the same from another node in the same cluster.
* Stop the EC2 instance. Verify from another node in the same consul cluster that the shutdown instance is now showing up with status as `left`.
* Start the EC2 instance after a few minutes.
* Check if its private/public IP addresses have changed.
* If either address has changed, verify that the consul configuration file `/etc/consul/config.json` has all its parameters updated to match the updated IP addresses.
* Repeat the steps mentioned before to verify the consul membership and the status of the instance in the cluster.
* Optionally, attach an elastic IP address to the instance and restart the consul service. Verify that the configuration has been updated properly, the service is running properly and the consul cluster membership has been updated appropriately by following the steps mentioned before.
* Create an AMI from the EC2 instance and create a new auto-scaling group. Set the created AMI in the launch template.
* Launch a new EC2 instance via the auto-scaling group. Once it is ready, check and verify its consul configuration, service status and cluster membership using the steps mentioned before.
* Also verify that the existing behaviour is retained when `consul_auto_generate_config` is not specified or set to a falsey value.

**Author notes and concerns**:
* This PR introduces yet another flag and adds to the existing clutter.
* A service restart is required to detect IP address changes on a running EC2 instance, for example, when an elastic IP address is attached or removed.
* Works only on AWS.