### PR TITLE
Update python version from 3.6.9 to 3.6.10

### DIFF
--- a/playbooks/roles/ocim/defaults/main.yml
+++ b/playbooks/roles/ocim/defaults/main.yml
@@ -67,7 +67,7 @@ opencraft_root_dir: '/var/www/opencraft'
 opencraft_static_files_dir: '{{ opencraft_root_dir }}/build/static'
 opencraft_screenrc_path: '/home/ubuntu/ocim-screenrc'
 
-ocim_python_version: '3.6.9'
+ocim_python_version: '3.6.10'
 pyenv_home: "{{ www_data_home_dir }}"
 pyenv_root: "{{ pyenv_home }}/.pyenv"
 opencraft_virtualenv_name: "opencraft"

--- a/playbooks/roles/ocim/tasks/vagrant.yml
+++ b/playbooks/roles/ocim/tasks/vagrant.yml
@@ -10,6 +10,12 @@
     force: no
   become_user: "{{ www_user }}"
 
+- name: Set HUEY_ALWAYS_EAGER to false
+  replace:
+    path: "{{ opencraft_root_dir }}/.env"
+    regexp: "^HUEY_ALWAYS_EAGER=true$"
+    replace: "HUEY_ALWAYS_EAGER=false"
+
 - name: Install javascript dependencies
   shell: DEBIAN_FRONTEND=noninteractive make install_js_dependencies
   args:

--- a/playbooks/roles/pyenv/defaults/main.yml
+++ b/playbooks/roles/pyenv/defaults/main.yml
@@ -1,7 +1,7 @@
 pyenv_home: "{{ ansible_env.HOME }}"
 pyenv_root: "{{ pyenv_home }}/.pyenv"
 
-pyenv_version: 'v1.2.13'
+pyenv_version: 'v1.2.16'
 pyenv_virtualenv_version: 'v1.1.5'
 
 
@@ -10,7 +10,7 @@ pyenv_python_versions: []
 
 # Takes a list of key-value pairs of the form
 # pyenv_virtualenv_environments:
-#   - python_version: '3.6.9'
+#   - python_version: '3.6.10'
 #     virtualenv_name: 'venv'
 pyenv_virtualenv_environments: []
 


### PR DESCRIPTION
This PR bumps the python version from 3.6.9 to 3.6.10. This also requires an update to pyenv to the [version](https://github.com/pyenv/pyenv/blob/master/CHANGELOG.md#1216) that supports python 3.6.10.