### PR TITLE
Allow installing Ocim devstack to any Ubuntu server

### DIFF
--- a/playbooks/ocim-devstack.yml
+++ b/playbooks/ocim-devstack.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Deploy the OpenCraft Instance Manager devstack
+  hosts: all
+  become: true
+  vars:
+    devstack: True
+    www_user: ubuntu
+    www_group: users
+    www_data_home_dir: '/home/ubuntu'
+    # The `opencraft` sources must be previously available.  The devstack tasks
+    # will not clone it automatically.
+    opencraft_root_dir: '{{ www_data_home_dir }}/src/ocim'
+    opencraft_virtualenv_dir: '{{ www_data_home_dir }}/venvs/ocim'
+  tasks:
+    - import_role:
+        name: ocim
+        tasks_from: devstack

--- a/playbooks/ocim-vagrant.yml
+++ b/playbooks/ocim-vagrant.yml
@@ -4,6 +4,7 @@
   hosts: all
   become: true
   vars:
+    devstack: True
     www_user: vagrant
     www_group: users
     # Install the app code and data the Vagrant home directory instead of /var/www
@@ -19,4 +20,4 @@
         autoremove: yes
     - import_role:
         name: ocim
-        tasks_from: vagrant
+        tasks_from: devstack

--- a/playbooks/roles/ocim/meta/main.yml
+++ b/playbooks/roles/ocim/meta/main.yml
@@ -1,7 +1,7 @@
 dependencies:
 
   - name: tarsnap
-    when: OPENCRAFT_BACKUP_SWIFT_ENABLED and www_user != 'vagrant'
+    when: OPENCRAFT_BACKUP_SWIFT_ENABLED and not devstack
 
   - name: nginx-proxy
     NGINX_PROXY_CONFIG_PATH: /etc/nginx/sites-available/ocim
@@ -11,7 +11,7 @@ dependencies:
     NGINX_PROXY_SEND_TIMEOUT: 600s
     NGINX_PROXY_READ_TIMEOUT: 600s
     NGINX_PROXY_EXTRA_CONFIG: "{{ opencraft_nginx_static_config + opencraft_nginx_websocket_config }}"
-    when: www_user != 'vagrant'
+    when: not devstack
 
   - name: pyenv
     pyenv_home: "{{ www_data_home_dir }}"

--- a/playbooks/roles/ocim/tasks/devstack.yml
+++ b/playbooks/roles/ocim/tasks/devstack.yml
@@ -27,14 +27,14 @@
   args:
     chdir: "{{ opencraft_root_dir }}"
 
-- name: Change directory to ~/opencraft on login
+- name: Change directory to sources on login
   blockinfile:
     path: ~/.bashrc
     marker: "# {mark} ANSIBLE MANAGED BLOCK activate_virtualenv"
     block: |
-      pyenv activate opencraft
-      cd ~/opencraft
-  become_user: vagrant
+      pyenv activate {{ opencraft_virtualenv_name }}
+      cd {{ opencraft_root_dir }}
+  become_user: "{{ www_user }}"
 
 - name: Setup Databases
   block:
@@ -43,7 +43,7 @@
         sudo -H -u root mysql mysql
 
     - name: Create Postgres user
-      shell: createuser -d vagrant
+      shell: createuser -d {{ www_user }}
       become_user: postgres
       ignore_errors: yes
 
@@ -61,4 +61,4 @@
 
     - name: Create postgres database
       command: make create_db chdir={{ opencraft_root_dir }}
-      become_user: vagrant
+      become_user: "{{ www_user }}"


### PR DESCRIPTION
Make the ocim devstack plays a little less Vagrant-opinionated, and create a generic devstack playbook that works on any standard Ubuntu server install.