### PR TITLE
[BB-2278] Leave the IP address dots as-is in the auto-generated consul node name

### DIFF
--- a/playbooks/roles/consul/templates/update_consul_config.py.j2
+++ b/playbooks/roles/consul/templates/update_consul_config.py.j2
@@ -42,8 +42,8 @@ def main():
         node_name_prefix = "{{ consul_nodename }}"
         generated_node_name = '{}-{}-{}'.format(
             node_name_prefix,
-            private_ip_address.replace('.', '-'),
-            public_ip_address.replace('.', '-'),
+            private_ip_address,
+            public_ip_address,
         )
         if (public_ip_address != advertise_address or
                 generated_node_name != node_name):


### PR DESCRIPTION
@Agrendalath, here is the fix that you recommended - to leave the dots in the IP addresses intact and not convert them to hyphens in the auto-generated consul node names.