### PR TITLE
[BB-2329] Remove the assumption that ocim domain name is always the same as the hostname

### DIFF
--- a/playbooks/group_vars/ocim/public.yml
+++ b/playbooks/group_vars/ocim/public.yml
@@ -6,8 +6,8 @@ COMMON_SERVER_NO_BACKUPS: true
 
 # CERTBOT #####################################################################
 
-CERTBOT_DOMAIN_NAME: "{{ OPENCRAFT_DOMAIN_NAME }}"
-CERTBOT_ADDITIONAL_DOMAINS: []
+CERTBOT_ADDITIONAL_DOMAINS:
+  - "{{ OPENCRAFT_DOMAIN_NAME }}"
 
 # PROMETHEUS ##################################################################
 


### PR DESCRIPTION
This allows the Ocim app's virtual host name and the hostname of the VM running the app to be different. `CERTBOT_DOMAIN_NAME` will now use the default of `inventory_hostname` which works correctly with the `node-exporter` virtual host and the `ocim` virtual host.