### PR TITLE
[SE-2948] Remove redirect to preliminary page

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -135,7 +135,7 @@ backend be-{{$config.domain_slug}}
     server unscheduled-maintenance-page 127.0.0.1:{{! maintenance_unscheduled_server_port !}}
       {{- end }}
     {{- else }}
-    server preliminary-page {{! preliminary_page_server_ip !}}:80
+    server preliminary-page {{! preliminary_page_server_ip !}}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
     http-request set-header Host 'default.opencraft.com'
     {{- end }}
     {{- end }}


### PR DESCRIPTION
When no appservers are active, instance LMS and Studio URLs should not redirect the user, but just display contents of default.opencraft.com. Have applied the patch manually to the below instance on stage too, for testing purposes.

**JIRA tickets**: [SE-2948](https://tasks.opencraft.com/browse/SE-2948)

**Sandbox URL**: https://sid-test-2.stage.opencraft.hosting (The DNS has 3 IP addresses, so you might see the old deployment on IPs other than 54.36.101.120)

**Testing instructions**:

1. Run `curl --insecure -v --header "Host:se-2870-test.opencraft.hosting" https://54.36.101.120` and verify 301 Moved Permanently response.
2. Run `curl --insecure -v --header "Host:sid-test-2.stage.opencraft.hosting" https://54.36.101.120` and verify 200 OK is returned, with content of default.opencraft.com
3. Verify that `backend be-edxins-sid-test-2sta-567` section of `/etc/haproxy/haproxy.cfg` on stage haproxy has the updated code.

**Reviewers**
- [ ] @mtyaka 