### PR TITLE
[BB-2851] Huey queue monitor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "playbooks/roles/geerlingguy.php-versions"]
 	path = playbooks/roles/geerlingguy.php-versions
 	url = https://github.com/geerlingguy/ansible-role-php-versions
+[submodule "playbooks/roles/prometheus_redis_exporter_role"]
+	path = playbooks/roles/prometheus_redis_exporter_role
+	url = https://github.com/idealista/prometheus_redis_exporter_role

--- a/playbooks/group_vars/prometheus/public.yml
+++ b/playbooks/group_vars/prometheus/public.yml
@@ -35,6 +35,9 @@ PROMETHEUS_ALERT_DISK_SPACE_THRESHOLD: 80
 PROMETHEUS_ALERT_HTTP_RESPONSE_TIME_THRESHOLD: 1
 PROMETHEUS_ALERT_HTTP_RESPONSE_FRONTEND_ERROR_THRESHOLD: 70
 
+OCIM_QUEUE_REDIS_KEY: null
+PROMETHEUS_ALERT_OCIM_QUEUE_SIZE_THRESHOLD: null
+
 prometheus_rules:
   - name: NodeRules
     rules:
@@ -161,7 +164,17 @@ prometheus_rules:
       annotations:
         summary: "MongoDB instance [[ $labels.node ]] ([[ $labels.instance ]]) down."
         description: "[[ $labels.node ]] ([[ $labels.instance ]]) of job [[ $labels.job ]] is down."
-
+  - name: "OcimQueueSizeRule"
+    rules:
+    - alert: "ocim_queue_too_big"
+      expr: 'redis_key_size{key="{{ OCIM_QUEUE_REDIS_KEY }}"} > {{ PROMETHEUS_ALERT_OCIM_QUEUE_SIZE_THRESHOLD }}'
+      for: "0s"
+      labels:
+        severity: "critical"
+        environment: "[[ $labels.environment ]]"
+      annotations:
+        summary: "Ocim queue overloaded."
+        description: "Ocim queue overloaded."
 # ALERT MANAGER ################################################################
 
 prometheus_alert_manager_web__listen_address: "127.0.0.1:9093"

--- a/playbooks/ocim.yml
+++ b/playbooks/ocim.yml
@@ -9,3 +9,9 @@
 
     - role: ocim
       tags: 'ocim'
+
+    - role: redis-exporter
+      tags: 'redis-exporter'
+      REDIS_EXPORTER_CHECK_KEYS: "{{ OCIM_QUEUE_REDIS_KEY }}"
+      REDIS_EXPORTER_REDIS_ADDR: "{{ OCIM_REDIS_ADDRESS }}"
+      when: REDIS_EXPORTER_PASSWORD is not none

--- a/playbooks/roles/redis-exporter/README.md
+++ b/playbooks/roles/redis-exporter/README.md
@@ -1,0 +1,18 @@
+redis-exporter
+==============
+
+Extends [prometheus_redis_exporter_role](https://github.com/idealista/prometheus_redis_exporter_role)
+to expose the size of the specified Redis key.
+
+Role Variables
+--------------
+
+Check available variables here:
+- `playbooks/roles/prometheus_redis_exporter_role/defaults/main.yml`
+- `playbooks/roles/redis-exporter/defaults/main.yml`
+
+Dependencies
+------------
+
+- nginx-proxy
+- [prometheus_redis_exporter_role](https://github.com/idealista/prometheus_redis_exporter_role)

--- a/playbooks/roles/redis-exporter/defaults/main.yml
+++ b/playbooks/roles/redis-exporter/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# The basic auth password to access the redis exporter.
+REDIS_EXPORTER_PASSWORD: null
+
+REDIS_EXPORTER_NGINX_CONFIG_PATH: /etc/nginx/sites-available/redis-exporter
+REDIS_EXPORTER_HTPASSWD_PATH: /etc/nginx/htpasswd
+
+REDIS_EXPORTER_USE_SSL: true
+
+REDIS_EXPORTER_REDIS_ADDR: null
+REDIS_EXPORTER_CHECK_KEYS: null
+
+REDIS_EXPORTER_CONSUL_SERVICE:
+  service:
+    name: redis-exporter
+    tags:
+      - redis-exporter
+      - "{{ 'monitor-https' if REDIS_EXPORTER_USE_SSL else 'monitor' }}"
+    port: 19103
+    enable_tag_override: true

--- a/playbooks/roles/redis-exporter/handlers/main.yml
+++ b/playbooks/roles/redis-exporter/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reload consul
+  shell: "if command -v consul; then consul reload; fi"

--- a/playbooks/roles/redis-exporter/meta/main.yml
+++ b/playbooks/roles/redis-exporter/meta/main.yml
@@ -1,0 +1,17 @@
+---
+  dependencies:
+    - name: prometheus_redis_exporter_role
+      redis_exporter_redis_addr: "{{ REDIS_EXPORTER_REDIS_ADDR }}"
+      redis_exporter_check_keys: "{{ REDIS_EXPORTER_CHECK_KEYS }}"
+    - name: nginx-proxy
+      NGINX_PROXY_HTPASSWD_PATH: "{{ REDIS_EXPORTER_HTPASSWD_PATH }}"
+      # The username is a bit misleading – should actually be "prometheus", since it's the server
+      # authenticating, and the same username is used for scraping other exporters, but it's not worth
+      # the hassle to change it.
+      NGINX_PROXY_USERNAME: node-exporter
+      NGINX_PROXY_PASSWORD: "{{ REDIS_EXPORTER_PASSWORD }}"
+      NGINX_PROXY_AUTH_DOMAIN: Prometheus Redis Exporter
+      NGINX_PROXY_CONFIG_PATH: "{{ REDIS_EXPORTER_NGINX_CONFIG_PATH }}"
+      NGINX_PROXY_PUBLIC_PORT: 19103
+      NGINX_PROXY_INTERNAL_PORT: 9121
+      NGINX_PROXY_USE_SSL: "{{ REDIS_EXPORTER_USE_SSL }}"

--- a/playbooks/roles/redis-exporter/tasks/main.yml
+++ b/playbooks/roles/redis-exporter/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+  - name: create Consul config directory
+    file:
+      path: /etc/consul
+      state: directory
+
+  - name: create Consul service definition file
+    copy:
+      content: "{{ REDIS_EXPORTER_CONSUL_SERVICE | to_nice_json }}"
+      dest: /etc/consul/redis-exporter.json
+    notify:
+      - reload consul


### PR DESCRIPTION
##### Task - [BB-2851](https://tasks.opencraft.com/browse/BB-2851)

#### Description
Adds a new ``redis-exporter`` role to send ``redis`` metrics to ``prometheus``. It uses [prometheus_redis_exporter_role](https://github.com/idealista/prometheus_redis_exporter_role) as dependency and adds nginx & consul configurations to work with Ocim infrastructure.