### PR TITLE
Fix issues with the load-balancer-v2 role

### DIFF
--- a/playbooks/roles/load-balancer-v2/tasks/main.yml
+++ b/playbooks/roles/load-balancer-v2/tasks/main.yml
@@ -25,6 +25,18 @@
     - ssl-cert
     - jq
 
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0700"
+  with_items:
+    - "/etc/haproxy/certs"
+    - "/etc/haproxy/certs/ocim"
+    - "/etc/haproxy/conf.d"
+    - "/etc/haproxy/backends"
+    - "/etc/letsencrypt/live"
+
 - name: Copy over Go templates for generating HAProxy configuration files
   # The ctmpl files use `{{` and `}}` as Go template start- and end- strings.
   # So for Jinja2 rendering we'll use `!` next to the original delimiters.
@@ -162,18 +174,6 @@
     minute: 42
     cron_file: letsencrypt-renew
     user: root
-
-- name: Create directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    mode: "0700"
-  with_items:
-    - "/etc/haproxy/certs"
-    - "/etc/haproxy/certs/ocim"
-    - "/etc/haproxy/conf.d"
-    - "/etc/haproxy/backends"
-    - "/etc/letsencrypt/live"
 
 - name: Enable and start the services
   systemd:

--- a/playbooks/roles/load-balancer-v2/tasks/main.yml
+++ b/playbooks/roles/load-balancer-v2/tasks/main.yml
@@ -191,6 +191,9 @@
     path: "/etc/letsencrypt/live/{{ CERTBOT_DOMAIN_NAME }}/fullchain.pem"
   register: lb_cert_p
 
+- import_tasks: maintenance.yml
+  tags: 'site-is-down'
+
 - name: Bootstrap the local certificate
   block:
     - name: Find config files that will stop nginx from reloading
@@ -219,9 +222,6 @@
   notify:
     - reload nginx
   when: lb_cert_p.stat.exists == False
-
-- import_tasks: maintenance.yml
-  tags: 'site-is-down'
 
 - import_tasks: exporter.yml
   when: haproxy_exporter_enabled


### PR DESCRIPTION
Some tasks had to be moved around:

1. Directories under `/etc` need to be created early, before the first task that depends on them
2. The `maintenance.yml` tasks need to run before the tasks from the certbot role. The cerbot role needs a running haproxy (to proxy requests to local nginx), but haproxy won't start if the `maint.map` file created by `maintenance.yml` doesn't exist.

**Testing**:

I don't see any way to properly test this without running it on a fresh server, which is a lot of trouble :/ Since the changes are minor (just changing the order of the tasks), I suppose we could skip a full manual test.

**Reviewers**:

- [x] @swalladge 