### PR TITLE
[BB-1716] Enable node-exporter explicitly

### DIFF
--- a/playbooks/roles/node-exporter/tasks/main.yml
+++ b/playbooks/roles/node-exporter/tasks/main.yml
@@ -11,9 +11,6 @@
   notify:
     - reload consul
 
-- name: flush handlers
-  meta: flush_handlers
-
 - name: enable nodeexporter
   systemd:
     name: nodeexporter.service

--- a/playbooks/roles/node-exporter/tasks/main.yml
+++ b/playbooks/roles/node-exporter/tasks/main.yml
@@ -10,3 +10,13 @@
     dest: /etc/consul/node-exporter.json
   notify:
     - reload consul
+
+- name: flush handlers
+  meta: flush_handlers
+
+- name: enable nodeexporter
+  systemd:
+    name: nodeexporter.service
+    enabled: yes
+    state: started
+    daemon_reload: yes

--- a/playbooks/roles/sprints/tasks/main.yml
+++ b/playbooks/roles/sprints/tasks/main.yml
@@ -8,14 +8,6 @@
     - 80
     - 443
 
-# For some reason this service wasn't started after running playbooks.
-- name: Enable and start node-exporter systemd service to start on boot automatically
-  systemd:
-    name: nodeexporter.service
-    enabled: yes
-    state: started
-    daemon_reload: yes
-
 - name: Set authorized key for CircleCI
   authorized_key:
     user: ubuntu


### PR DESCRIPTION
This PR explicitly enables node-exporter during provisioning. It fixes an issue where sometimes node-exporter is active but not enabled and hence doesn't restart automatically on reboot.

**JIRA tickets**: 

**Discussions**: 

**Dependencies**: None

**Screenshots**: 

**Sandbox URL**: 

**Merge deadline**: None

**Testing instructions**:

1. Setup a virtualenv and install all requirements
2. Create a fresh ubuntu 16.04 vagrant box
3. Run any provisioning script (such as sprints.yml) through ansible
4. Use 'vagrant ssh' and 'systemctl status nodeexporter' to confirm node-exporter is working
5. Use 'vagrant reload'
6. Use 'vagrant ssh' and 'systemctl status nodeexporter' to confirm node-exporter is working

**Author notes and concerns**:

1. I believe this should fix the problem, and i tried multiple failure situations where without this code node-exporter is not running but with this code node-exporter is running. But node-exporter seems to be auto-disabled if it's not able to contact consul in which case this would not fix the problem (But since a similar approach was tried by @Agrendalath and it successfully fixed the issue with the sprints app, that's unlikely to be the case)

**Reviewers**
- [x] @giovannicimolin 

```