### PR TITLE
[BB-2231] Allow configuring a failure alert email address for cert-manager

### DIFF
--- a/playbooks/roles/cert-manager/defaults/main.yml
+++ b/playbooks/roles/cert-manager/defaults/main.yml
@@ -14,5 +14,7 @@ cert_manager_consul_certs_prefix: "ocim/certs"
 cert_manager_consul_watch_prefix: "ocim/instances"
 cert_manager_consul_lock_prefix: "lock/ocim"
 
+cert_manager_alert_email: ''
+
 cert_manager_watch_delay: 120
 cert_manager_dns_delay: 60

--- a/playbooks/roles/cert-manager/defaults/main.yml
+++ b/playbooks/roles/cert-manager/defaults/main.yml
@@ -14,7 +14,7 @@ cert_manager_consul_certs_prefix: "ocim/certs"
 cert_manager_consul_watch_prefix: "ocim/instances"
 cert_manager_consul_lock_prefix: "lock/ocim"
 
-cert_manager_alert_email: ''
+cert_manager_failure_alert_email: ''
 
 cert_manager_watch_delay: 120
 cert_manager_dns_delay: 60

--- a/playbooks/roles/cert-manager/templates/cert-manager.sh
+++ b/playbooks/roles/cert-manager/templates/cert-manager.sh
@@ -19,4 +19,5 @@ consul watch -type=keyprefix -prefix={{ cert_manager_consul_watch_prefix }} \
              --webroot-path {{ cert_manager_webroot_path }} \
              --consul-ocim-prefix {{ cert_manager_consul_ocim_prefix }} \
              --consul-certs-prefix {{ cert_manager_consul_certs_prefix }} \
+             {% if cert_manager_failure_alert_email %}--failure-alert-email {{ cert_manager_failure_alert_email }} \{% endif %}
              --dns-delay {{ cert_manager_dns_delay }}"


### PR DESCRIPTION
This PR enables using the `--failure-alert-email` option added to `cert-manager` in https://github.com/open-craft/cert-manager/pull/15.

**Testing instructions**:
* Deploy the changes in this PR branch on a `cert-manager` instance with `cert_manager_alert_email` set to a valid email address using Ansible variable overrides.
* Verify that the `--failure-alert-email` option is passed correctly to `cert-manager` in the generated `cert-manager.sh` script
* Verify that the `cert-manager` sends an email to the configured address when there is a certificate provisioning failure (already verified in https://github.com/open-craft/cert-manager/pull/15).
* Verify that a proper, working `cert-manager` command without this option is generated in the `cert-manager.sh` script when the default value for `cert_manager_failure_alert_email` is not overridden.
