### PR TITLE
[BB-3018] Load balancers should serve the maintenance pages from the local nginx vhosts and not redirect to external domains

### DIFF
--- a/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
@@ -6,7 +6,11 @@
   {{- with $config := .Value | parseJSON }}
     {{- if $config }}
       {{- range $lb_domain := $config.domains }}
+        {{- if $config.active_app_servers }}
 {{ $lb_domain }} be-{{ $config.domain_slug }}
+        {{- else }}
+{{ $lb_domain }} provisioning
+        {{- end }}
       {{- end }}
     {{- end}}
   {{- end }}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -119,6 +119,7 @@ backend provisioning
   {{- with $config := .Value | parseJSON }}
     {{- if $config }}
     {{ $health_check := $config.health_checks_enabled }}
+    {{- if $config.active_app_servers }}
 # Backend configuration for {{ $config.domain }}
 backend be-{{$config.domain_slug}}
     cookie openedx-backend insert postonly indirect
@@ -134,9 +135,7 @@ backend be-{{$config.domain_slug}}
     http-response redirect location / unless { capture.req.uri / }
     server unscheduled-maintenance-page 127.0.0.1:{{! maintenance_unscheduled_server_port !}}
       {{- end }}
-    {{- else }}
-    server preliminary-page {{! preliminary_page_server_ip !}}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
-    http-request set-header Host 'default.opencraft.com'
+    {{- end }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -117,9 +117,8 @@ backend provisioning
 {{- /* Print config in the form of a single K/V value. */ -}}
 {{- range ls $prefix }}
   {{- with $config := .Value | parseJSON }}
-    {{- if $config }}
+    {{- if and $config $config.active_app_servers }}
     {{ $health_check := $config.health_checks_enabled }}
-    {{- if $config.active_app_servers }}
 # Backend configuration for {{ $config.domain }}
 backend be-{{$config.domain_slug}}
     cookie openedx-backend insert postonly indirect
@@ -135,7 +134,6 @@ backend be-{{$config.domain_slug}}
     http-response redirect location / unless { capture.req.uri / }
     server unscheduled-maintenance-page 127.0.0.1:{{! maintenance_unscheduled_server_port !}}
       {{- end }}
-    {{- end }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/playbooks/roles/load-balancer-v2/templates/nginx-maintenance.conf
+++ b/playbooks/roles/load-balancer-v2/templates/nginx-maintenance.conf
@@ -35,7 +35,7 @@ server {
     error_page 503 =503 @error;
 
     location @error {
-        try_files /$host/error.html /default/error.html;
+        try_files /$host/scheduled.html /default/scheduled.html;
     }
 
     location ~ ^/error/static/(.*)$ {
@@ -60,7 +60,7 @@ server {
     error_page 503 =503 @error;
 
     location @error {
-        try_files /$host/error.html /default/error.html;
+        try_files /$host/unscheduled.html /default/unscheduled.html;
     }
 
     location ~ ^/error/static/(.*)$ {


### PR DESCRIPTION
This PR fixes the wrong maintenance page issue during scheduled or unscheduled maintenance and during provisioning.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3018

~~**Discussions**:~~
 
**Dependencies**: None

~~**Screenshots**: ~~
~~**Sandbox URL**:~~

**Merge deadline**: "None"

**Testing instructions**:
1. Move an instance to maintenance mode, proper maintenance page should show
2. Provisioning page should show from local Nginx instead of using external server IP

~~**Author notes and concerns**:~~

**Reviewers**
- [ ] @lgp171188 

~~**Settings**~~