### PR TITLE
SE-3328 Add newrelic infra and rabbit integration

### DIFF
--- a/playbooks/roles/newrelic_infra/README.md
+++ b/playbooks/roles/newrelic_infra/README.md
@@ -1,0 +1,10 @@
+Newrelic infrastructure agent
+===================
+
+This role is meant to run on any VM that requires the newrelic infrastructure agent installed.
+Supports Ubuntu 16.
+
+Role Variables
+--------------
+
+- `NEWRELIC_LICENSE_KEY`: this is the license key attached to the newrelic account.  This can be found on your account settings page in newrelic.

--- a/playbooks/roles/newrelic_infra/defaults/main.yml
+++ b/playbooks/roles/newrelic_infra/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# required
+NEWRELIC_LICENSE_KEY: null

--- a/playbooks/roles/newrelic_infra/tasks/main.yml
+++ b/playbooks/roles/newrelic_infra/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: ensure /etc/newrelic-infra.yml is present
+  template:
+    src: newrelic-infra.yml.j2
+    dest: "/etc/newrelic-infra.yml"
+
+- name: ensure newrelic apt repository gpg key is added
+  apt_key:
+    url: "https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg"
+    state: present
+
+- name: ensure newrelic apt repository is registered
+  apt_repository:
+    repo: "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt xenial main"
+    state: present
+
+- name: ensure newrelic infra plugin is installed
+  apt:
+    name: "newrelic-infra"
+    state: present

--- a/playbooks/roles/newrelic_infra/templates/newrelic-infra.yml.j2
+++ b/playbooks/roles/newrelic_infra/templates/newrelic-infra.yml.j2
@@ -1,0 +1,4 @@
+### WARNING: ###
+# This file is managed via Ansible.  Manual changes to this file will be overwritten.
+################
+license_key: {{ NEWRELIC_LICENSE_KEY }}

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -34,9 +34,5 @@ RABBITMQ_SCRIPTS_DIR: /usr/local/sbin
 RABBITMQ_BACKUP_COMMAND: rabbitmq-backup
 RABBITMQ_RESTORE_COMMAND: rabbitmq-restore
 
-RABBITMQ_USER: set-me-please
-RABBITMQ_PASS: set-me-please
-RABBITMQ_VHOST: set-me-please
-
 # Update the version below if RABBITMQ_VERSION is changed
 RABBITMQADMIN_URL: https://raw.githubusercontent.com/rabbitmq/rabbitmq-management/v3.6.x/bin/rabbitmqadmin

--- a/playbooks/roles/rabbitmq/meta/main.yml
+++ b/playbooks/roles/rabbitmq/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: newrelic_infra

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -163,23 +163,10 @@
     user: guest
     state: absent
 
-- name: add rabbitmq vhost
-  rabbitmq_vhost:
-    name: "{{ RABBITMQ_VHOST }}"
-    node: "rabbit@{{ RABBITMQ_HOSTNAME }}"
-    state: present
-
-- name: create rabbitmq user
-  rabbitmq_user:
-    user: "{{ RABBITMQ_USER }}"
-    password: "{{ RABBITMQ_PASS }}"
-    vhost: "{{ RABBITMQ_VHOST }}"
-    state: present
-
+# TODO: what is this used for?
 - name: ensure vhost /test is present
   rabbitmq_vhost:
     name: /test
-    node: "rabbit@{{ RABBITMQ_HOSTNAME }}"
     state: present
 
 - name: ensure newrelic rabbitmq monitoring is present

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -181,3 +181,27 @@
     name: /test
     node: "rabbit@{{ RABBITMQ_HOSTNAME }}"
     state: present
+
+- name: ensure newrelic rabbitmq monitoring is present
+  apt:
+    pkg: "nri-rabbitmq"
+    state: present
+  register: rabbit_newrelic
+  tags:
+    - rabbitmq-newrelic
+
+- name: ensure /etc/newrelic-infra/integrations.d/rabbitmq-config.yml is present
+  template:
+    src: rabbitmq-config-newrelic-infra.yml.j2
+    dest: "/etc/newrelic-infra/integrations.d/rabbitmq-config.yml"
+  register: rabbit_newrelic_config
+  tags:
+    - rabbitmq-newrelic
+
+- name: restart newrelic-infra if changed
+  systemd:
+    name: newrelic-infra
+    state: restarted
+  when: rabbit_newrelic.changed or rabbit_newrelic_config.changed
+  tags:
+    - rabbitmq-newrelic

--- a/playbooks/roles/rabbitmq/templates/rabbitmq-config-newrelic-infra.yml.j2
+++ b/playbooks/roles/rabbitmq/templates/rabbitmq-config-newrelic-infra.yml.j2
@@ -1,0 +1,21 @@
+### WARNING: ###
+# This file is managed via Ansible.  Manual changes to this file will be overwritten.
+################
+integration_name: com.newrelic.rabbitmq
+
+instances:
+  - name: "{{ RABBITMQ_HOSTNAME }}"
+    command: all
+    arguments:
+      hostname: "{{ RABBITMQ_HOSTNAME }}"
+      port: "{{ RABBITMQ_HTTPS_PORT }}"
+      username: "{{ RABBITMQ_ADMIN_USERNAME }}"
+      password: "{{ RABBITMQ_ADMIN_PASSWORD }}"
+      config_path: "/etc/rabbitmq/rabbitmq.config"
+      use_ssl: true
+      queues_regexes: '[".*"]'
+      exchanges_regexes: '[".*"]'
+      vhosts_regexes: '[".*"]'
+    labels:
+      env: "{{ RABBITMQ_HOSTNAME }}"
+      role: rabbitmq


### PR DESCRIPTION
This adds support for newrelic infrastructure plugin with the rabbitmq integration running on rabbitmq instances.  It should allow us to collect metrics on rabbitmq, and use those metrics for alerting (for example, if queue lengths go through the roof).

It also fixes some issues with running the playbook.

**Test instructions**:

- deploy rabbitmq and verify that it completes successfully
- check newrelic and verify that it is receiving metrics from the rabbitmq instance