### PR TITLE
SE-3328 Tag the newrelic_infra dependency

### DIFF
--- a/playbooks/roles/rabbitmq/meta/main.yml
+++ b/playbooks/roles/rabbitmq/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
   - role: newrelic_infra
+    tags:
+      - rabbitmq-newrelic


### PR DESCRIPTION
This allows using the `rabbitmq-newrelic` tag to run all newrelic
related tasks for rabbtimq hosts.  Just for convenience.

**Test instructions**:

- run the playbook against a rabbitmq server with the `rabbitmq-newrelic` tag (in some test mode if possible), and verify that the dependency is run also.

**Reviewers**:

- [x] @pomegranited 