### PR TITLE
[SE-3417] Remove unused MYSQL_OPENSTACK_DB_DEVICE variable.

### DIFF
--- a/playbooks/roles/mysql/README.md
+++ b/playbooks/roles/mysql/README.md
@@ -3,15 +3,11 @@ Mysql
 
 A role that deploys fully-working mysql server on OpenStack; it: 
 
-* Mounts `/var/lib/mysql` on `{{ MYSQL_OPENSTACK_DB_DEVICE }}` 
-  (this device should contain a formatted ext4 filesystem. 
 * Opens `3306` port 
 * Copies `pre` and `post` backup scripts. 
 
 Role Variables
 --------------
-
-``MYSQL_OPENSTACK_DB_DEVICE`` --- volume location e.g.: ``/dev/vdb1``
 
 ``MYSQL_SERVER_BACKUP_DIR`` --- a directory where database dumps temporarily stored. Please note that it will need to 
 have enough free space to hold dumps of all databases on the server.

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -2,7 +2,6 @@
 
 # GENERAL #####################################################################
 
-MYSQL_OPENSTACK_DB_DEVICE: /dev/vdb1
 MYSQL_SERVER_BACKUP_DIR: /var/lib/mysql/backup
 MYSQL_OPEN_FILES_LIMIT: 65536
 MYSQL_PROCESSES_LIMIT: 1024


### PR DESCRIPTION
It's not used anywhere in the playbook.

**Reviewers**:

- [ ] @mavidser