### PR TITLE
[SE-3417] Use certbot from snap in common-apache2 role.

### DIFF
--- a/playbooks/hxat-catchpy-loris.yml
+++ b/playbooks/hxat-catchpy-loris.yml
@@ -4,7 +4,7 @@
 # Apply common configuration to all hosts
 
 - hosts: catchpy:hxat:loris
-  
+  become: true
   roles:
     # The recommended configuration for these tools involved using apache2.
     # Our common-server role includes common-server-init, which installs nginx and can conflict with apache2.
@@ -12,6 +12,8 @@
     # For now, instead of using common-server we manually add the features we need, e.g. tarsnap for backups
     # The common-apache2 role also installs certbot
     - role: common-apache2
+  tags:
+    - common
 
 # Configure and deploy catchpy servers.
 - hosts: catchpy
@@ -45,13 +47,11 @@
 
 # Configure and deploy loris servers.
 - hosts: loris
-
   roles:
     # loris DB/images not backed up with tarsnap since no courses use image annotations yet
 
     - role: loris
       vars:
         ansible_python_interpreter: /usr/bin/python2
-  
   tags:
     - loris

--- a/playbooks/roles/common-apache2/files/certbot-renew.sh
+++ b/playbooks/roles/common-apache2/files/certbot-renew.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+PATH=/usr/bin:/bin:/usr/sbin:/snap/bin
+a2ensite -q 000-default.conf > /dev/null
+service apache2 reload
+certbot -q renew
+a2dissite -q 000-default.conf > /dev/null
+service apache2 reload

--- a/playbooks/roles/common-apache2/tasks/main.yml
+++ b/playbooks/roles/common-apache2/tasks/main.yml
@@ -1,13 +1,7 @@
 ---
 # This role contains common tasks that will run on all nodes.
 
-- name: add `ppa:certbot/certbot` repo
-  become: yes
-  apt_repository:
-    repo: ppa:certbot/certbot
-
 - name: install common packages
-  become: yes
   apt:
     name: "{{ packages }}"
     update_cache: yes
@@ -15,18 +9,51 @@
     packages:
     - apache2
     - build-essential
-    - certbot
     - git
     - libffi-dev
     - openssl
-    - python-certbot-apache
     - python-dev
     - python-pip
     - python-setuptools
 
+- name: Install snapd
+  apt:
+    name: snapd
+
+# TODO: We should switch to the snap ansible module after we upgrade to Ansible 2.8 or newer.
+- name: Install certbot snap
+  command: snap install certbot --classic
+
+# The systemd certbot renew timer that's included in the certbot snap package does not send an email on failure.
+# For this reason we disable the timer and use a custom cronfile with a MAILTO instead.
+- name: Disable systemd timer
+  systemd:
+    name: snap.certbot.renew.timer
+    state: stopped
+    enabled: no
+
 - name: include `certbot-renew.sh` script
   become: yes
-  template:
+  copy:
     src: certbot-renew.sh
     dest: /root/certbot-renew.sh
     mode: 0700
+
+# Custom cron job for renewing certificates. The only difference from the official snap systemd timer is
+# that this cron job will send an email to ops if any of the certificates fail to renew.
+- name: Create cron job to periodically renew certificates
+  cron:
+    name: certbot renew
+    user: root
+    job: "perl -e 'sleep int(rand(43200))' && /root/certbot-renew.sh"
+    minute: '0'
+    hour: '*/12'
+    cron_file: certbot-renew
+
+- name: Set MAILTO variable for certbot renew cron job
+  cron:
+    name: MAILTO
+    env: yes
+    job: ops@opencraft.com
+    user: root
+    cron_file: certbot-renew

--- a/playbooks/roles/common-apache2/templates/certbot-renew.sh
+++ b/playbooks/roles/common-apache2/templates/certbot-renew.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-PATH=/usr/bin:/bin:/usr/sbin
-a2ensite 000-default.conf
-service apache2 reload
-certbot renew
-a2dissite 000-default.conf
-service apache2 reload


### PR DESCRIPTION
This port the relevant parts from the [certbot role](https://github.com/open-craft/ansible-playbooks/tree/master/playbooks/roles/certbot) to `common-apache2`.

The most important part is upgrading certbot to the version provided as a snap package, which we also use on the rest of our servers, since the PPA installation method is no longer supported upstream and the version in the PPA is outdated.

**Test instructions**

This was deployed to the three servers that use this role:
- mit-catchpy.opencraft.hosting
- mit-hxat.opencraft.hosting
- mit-loris.opencraft.hosting

The first of the certificates will be up for renewal in about two weeks, so to verify that the renewal process is actually working we'll have to wait.
In order to review this PR, I think it's enough to read through the code make sure it makes sense.

**Reviewers**:
- [ ] @mavidser 