### PR TITLE
backup-pruner: don't modify /var/cache permissions

### DIFF
--- a/playbooks/roles/backup-pruner/tasks/main.yml
+++ b/playbooks/roles/backup-pruner/tasks/main.yml
@@ -6,12 +6,9 @@
 
 - name: create dirs
   file:
-    name: "{{ item }}"
+    name: /etc/tarsnap
     mode: 0700
     state: directory
-  with_items:
-    - /etc/tarsnap
-    - /var/cache
 
 # Note: tarsnapper requires keys to end with a newline
 # which are stripped from ansible variables.


### PR DESCRIPTION
The /var/cache folder already exist on Ubuntu (and most other linux distributions), so there's no need to create it in the backup-pruner playbook. In fact forcing `0700` permissions (which is stricter than the default) leads to some periodic system tasks failing.

**Testing**:

This is a trivial change and testing shouldn't be necessary.