### PR TITLE
[BB-3262] Add cleanup tmp task and tag

### DIFF
--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -137,28 +137,27 @@
         owner: mattermost
         group: mattermost
 
+- name: cleanup old Mattermost installer files to save disk space
+  block:
     - name: find old Mattermost installer files in /tmp
       find:
         paths: /tmp
         patterns: "mattermost-autolink*.tar.gz"
         recurse: no
-        register: all_mm_autolink
+      register: all_mm_autolink
       find:
         paths: /tmp
         patterns: "mattermost-team*.tar.gz"
         recurse: no
-        register: all_mm_team
+      register: all_mm_team
       tags:
         - cleanup_tmp
 
     - name: select all but the latest 2 installers for cleanup
       set_fact:
         num_autolink_found: "{{ all_mm_autolink.matched }}"
-      set_fact:
         num_team_found: "{{ all_mm_team.matched }}"
-      set_fact:
         autolink_delete: "{{ all_mm_autolink | sort(attribute='ctime')[:num_autolink_found-2] }}"
-      set_fact:
         team_delete: "{{ all_mm_team | sort(attribute='ctime')[:num_team_found-2] }}"
       tags:
         - cleanup_tmp

--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -136,3 +136,17 @@
         state: touch
         owner: mattermost
         group: mattermost
+
+    - name: cleanup old Mattermost installer files from /tmp
+      shell: find /tmp -maxdepth 1 -name 'mattermost-autolink*.tar.gz' | sort | head -n -2
+      register: old_mm_autolink
+      shell: find /tmp -maxdepth 1 -name 'mattermost-team*.tar.gz' | sort | head -n -2
+      register: old_mm_team
+      file:
+        path: "{{ item }}"
+        state: absent
+        with_items:
+          - old_mm_autolink
+          - old_mm_team
+      tags:
+        - cleanup_tmp

--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -137,16 +137,38 @@
         owner: mattermost
         group: mattermost
 
-    - name: cleanup old Mattermost installer files from /tmp
-      shell: find /tmp -maxdepth 1 -name 'mattermost-autolink*.tar.gz' | sort | head -n -2
-      register: old_mm_autolink
-      shell: find /tmp -maxdepth 1 -name 'mattermost-team*.tar.gz' | sort | head -n -2
-      register: old_mm_team
+    - name: find old Mattermost installer files in /tmp
+      find:
+        paths: /tmp
+        patterns: "mattermost-autolink*.tar.gz"
+        recurse: no
+        register: all_mm_autolink
+      find:
+        paths: /tmp
+        patterns: "mattermost-team*.tar.gz"
+        recurse: no
+        register: all_mm_team
+      tags:
+        - cleanup_tmp
+
+    - name: select all but the latest 2 installers for cleanup
+      set_fact:
+        num_autolink_found: "{{ all_mm_autolink.matched }}"
+      set_fact:
+        num_team_found: "{{ all_mm_team.matched }}"
+      set_fact:
+        autolink_delete: "{{ all_mm_autolink | sort(attribute='ctime')[:num_autolink_found-2] }}"
+      set_fact:
+        team_delete: "{{ all_mm_team | sort(attribute='ctime')[:num_team_found-2] }}"
+      tags:
+        - cleanup_tmp
+
+    - name: perform tmp cleanup of old installer files
       file:
         path: "{{ item }}"
         state: absent
         with_items:
-          - old_mm_autolink
-          - old_mm_team
+          - autolink_delete.files
+          - team_delete.files
       tags:
         - cleanup_tmp

--- a/playbooks/roles/mattermost/tasks/mattermost.yml
+++ b/playbooks/roles/mattermost/tasks/mattermost.yml
@@ -139,26 +139,30 @@
 
 - name: cleanup old Mattermost installer files to save disk space
   block:
-    - name: find old Mattermost installer files in /tmp
+    - name: find old Mattermost autolink installer files in /tmp
       find:
-        paths: /tmp
-        patterns: "mattermost-autolink*.tar.gz"
+        path: /tmp
+        pattern: 'mattermost-autolink.+\.tar\.gz'
         recurse: no
+        use_regex: yes
       register: all_mm_autolink
+      tags:
+        - cleanup_tmp
+      
+    - name: find old Mattermost team installer files in /tmp
       find:
-        paths: /tmp
-        patterns: "mattermost-team*.tar.gz"
+        path: /tmp
+        pattern: 'mattermost-team.+\.tar\.gz'
         recurse: no
+        use_regex: yes
       register: all_mm_team
       tags:
         - cleanup_tmp
 
     - name: select all but the latest 2 installers for cleanup
       set_fact:
-        num_autolink_found: "{{ all_mm_autolink.matched }}"
-        num_team_found: "{{ all_mm_team.matched }}"
-        autolink_delete: "{{ all_mm_autolink | sort(attribute='ctime')[:num_autolink_found-2] }}"
-        team_delete: "{{ all_mm_team | sort(attribute='ctime')[:num_team_found-2] }}"
+        autolink_delete: "{{ (all_mm_autolink.files|sort(attribute='mtime')|map(attribute='path')|list)[:all_mm_autolink.matched-2] }}"
+        team_delete: "{{ (all_mm_team.files|sort(attribute='mtime')|map(attribute='path')|list)[:all_mm_team.matched-2] }}"
       tags:
         - cleanup_tmp
 
@@ -166,8 +170,8 @@
       file:
         path: "{{ item }}"
         state: absent
-        with_items:
-          - autolink_delete.files
-          - team_delete.files
+      with_items:
+        - "{{ autolink_delete }}"
+        - "{{ team_delete }}"
       tags:
         - cleanup_tmp


### PR DESCRIPTION
For BB-3262: Added ansible task to cleanup old mattermost installer files from /tmp after updating.

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. Make copies of mattermost installer files in /tmp and change file names or redownload. The ansible task saves the 2 most recent versions of the autolink and teams installers, so there must be 3+ of each in the folder to test cleanup.
2. Run playbook with "--tags cleanup_tmp" and check that only the 2 most recent versions of each installer remains in /tmp. Check that disk space is at an acceptable level (i.e. around 50% usage).
3. Run playbook again without any extra installer files in /tmp to cleanup. Make sure that no errors are thrown.

**Reviewers**
- [ ] @0x29a 