### PR TITLE
Replace RabbitMQ CA cert file chain.pem -> fullchain.pem.

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -10,7 +10,7 @@ RABBITMQ_HOSTNAME: "{{ inventory_hostname }}"
 # side (will still be non zero if client requests.
 RABBITMQ_HEARTBEAT: 0
 
-RABBITMQ_CA_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/chain.pem"
+RABBITMQ_CA_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/fullchain.pem"
 RABBITMQ_CERTIFICATE_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/cert.pem"
 RABBITMQ_KEY_FILE: "/etc/letsencrypt/live/{{ RABBITMQ_HOSTNAME }}/privkey.pem"
 RABBITMQ_HIGH_MEMORY_ALARM: 0.8


### PR DESCRIPTION
RabbitMQ has to be configured with Let's Encrypt's fullchain.pem CA chaing to properly server the intermediate certificates.

Changing the `RABBITMQ_CA_CERTIFICATE_FILE` variable has the effect of changing two lines in `/etc/rabbitmq/rabbitmq.config`:
- [line 1](https://github.com/open-craft/ansible-playbooks/blob/dd5be37e7ba2fd25a0b24959f7b3da8d34380395/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2#L7)
- [line 2](https://github.com/open-craft/ansible-playbooks/blob/dd5be37e7ba2fd25a0b24959f7b3da8d34380395/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2#L18)

The changes were already manually applied on RabbitMQ stage and production.