### PR TITLE
BB-3716: Custom backends take precedence

### DIFF
--- a/playbooks/roles/load-balancer-v2/tasks/main.yml
+++ b/playbooks/roles/load-balancer-v2/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # !!!    Important     !!!
 # Run this role only on a single server at a time,
-# using 
+# using
 # `ansible-playbook -v deploy/playbooks/load-balancer-v2.yml \
 # -l haproxy-a-1.net.opencraft.hosting`, etc.
 # Test each server before continuing to the next.
@@ -53,6 +53,7 @@
     - src: "haproxy.cfg.ctmpl"
       dest: "/etc/consul-template/templates/haproxy.cfg.ctmpl"
       mode: "0644"
+  tags: 'haproxy-config'
 
 - name: Copy over Hashicorp Configuration Language files
   # These HCL files instruct consul-watch where to find the templates,
@@ -69,6 +70,7 @@
     - src: "haproxy.cfg.hcl.j2"
       dest: "/etc/consul-template/config/haproxy.cfg.hcl"
       mode: "0644"
+  tags: 'haproxy-config'
 
 - name: Copy over Consul watcher scripts
   # The template watcher watches for appserver configuration
@@ -240,4 +242,3 @@
 
 - import_tasks: site-is-up.yml
   tags: [ 'never', 'site-is-up' ]
-

--- a/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
@@ -1,5 +1,5 @@
-#jinja2:variable_start_string:'{{!', variable_end_string:'!}}'
-{{- /* Custom haproxy maps (written first, to take precedence over automated Ocim entries.). */ -}}
+#jinja2:variable_start_string:'{{!', variable_end_string:'!}}', trim_blocks:False
+{{- /* Custom haproxy maps (written first, to take precedence over automated Ocim entries in case there are same domains used there.). */ -}}
 {%- for cm in haproxy_custom_maps %}
   {%- for domain in cm.domains %}
 {{! domain !}} {{! cm.backend !}}

--- a/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/backend.map.ctmpl
@@ -1,4 +1,12 @@
 #jinja2:variable_start_string:'{{!', variable_end_string:'!}}'
+{{- /* Custom haproxy maps (written first, to take precedence over automated Ocim entries.). */ -}}
+{%- for cm in haproxy_custom_maps %}
+  {%- for domain in cm.domains %}
+{{! domain !}} {{! cm.backend !}}
+  {%- endfor %}
+{%- endfor %}
+
+{{- /* Ocim backend entries. */ -}}
 {{- $prefix := "/ocim/instances" }}
 
 {{- /* Print config in the form of a single K/V value. */ -}}
@@ -15,9 +23,3 @@
     {{- end}}
   {{- end }}
 {{- end }}
-{{- /* Extra entries from haproxy_custom_maps (Ansible). */ -}}
-{%- for cm in haproxy_custom_maps %}
-  {%- for domain in cm.domains %}
-{{! domain !}} {{! cm.backend !}}
-  {%- endfor %}
-{%- endfor %}


### PR DESCRIPTION
While working on adding m* client custom redirects, I found 2 bugs in the consul-template implementation:
1. Custom backends were rendered after Ocim ones, meaning that was not possible to override a given domain to point to a different backend (first one in the file is the one that counts). Fixed by: https://github.com/open-craft/ansible-playbooks/commit/86934facee094309c6b4211e0eb0a1af5fb04787
2. The custom domain-backend mapping was being incorrectly rendered, resulting in a giant line effectively ignored by `haproxy` (none of the current custom backends are working). Fixed by: https://github.com/open-craft/ansible-playbooks/commit/d48989c9ca462fa25994d3c6c3a77ada202ae26a

To test this, I've used the m* client domain:
Check `/etc/haproxy/backend.map` you'll see the first entry is 
```
m-client-domain be-redirect-mclientbackend
```
and the following ones are the Ocim rendered ones.
There's another `m-client-domain` down the file, which is ignored - haproxy matches the first, so our overrides need to be higher in the file.

You can see that instead of just opening the instance, it performs a 302 redirect (click on the links from https://github.com/open-craft/ansible-common-secrets/pull/23 to test).

**Testing instructions:**
1. Checkout this branch.
2. Make sure you have `master` on all the other branches (`secrets` and `common-secrets`).
3. Simplify the playbooks:
* Edit `deploy/playbooks/load-balancer-v2.yml` and comment out `common-server` and `node-exporter`
* Delete the contents of `deploy/playbooks/roles/load-balancer-v2/meta/main.yml`
* Comment out all tasks but `Copy over Go templates for generating HAProxy configuration files` from `deploy/playbooks/roles/load-balancer-v2/tasks/main.yml`
4. Add some dummy custom backends to the stage instance (edit `group_vars/load-balancer-v2-stage/public.yml`):
```
haproxy_custom_maps:
  - backend: "be-example"
    domains:
      - "some-domain.opencraft.hosting"

  - backend: "be-aaaa"
    domains:
      - "someasdfasdfasdfdomain.opencraft.hosting"
```
6. Run `ansible-playbook -v -l haproxy-stage-1.net.opencraft.hosting deploy/playbooks/load-balancer-v2.yml`.
7. Check that the output file is redered properly in haproxy stage:
```
{{- /* Custom haproxy maps (written first, to take precedence over automated Ocim entries.). */ -}}
some-domain.opencraft.hosting be-example
someasdfasdfasdfdomain.opencraft.hosting be-aaaa

{{- /* Ocim backend entries. */ -}}
{{- $prefix := "/ocim/instances" }}

...
```

**Reviewer:**
- [ ] @lgp171188 
