### PR TITLE
[BB-3686] Create separate requirements file for Ansible 2.8.17

### DIFF
--- a/requirements_ansible_2.8.17.txt
+++ b/requirements_ansible_2.8.17.txt
@@ -1,0 +1,3 @@
+ansible==2.8.17
+netaddr==0.7.19
+cryptography


### PR DESCRIPTION
Including separate requirements file, similar to https://github.com/open-craft/ansible-playbooks/blob/master/requirements.txt, but with Ansible 2.8.17, which is required to run playbooks against Ubuntu 20.04.

**JIRA tickets**:
- [BB-3686](https://tasks.opencraft.com/browse/BB-3686)

**Dependencies**:
- https://github.com/open-craft/opencraft/pull/713 depends on this PR.

**Testing instructions**:

Look https://github.com/open-craft/opencraft/pull/713.

**Reviewers**
- [ ] @shimulch 