### PR TITLE
[BB-3809] Upgrade matomo from v3 to v4.2

### DIFF
--- a/playbooks/roles/matomo/templates/docker-compose.yml.j2
+++ b/playbooks/roles/matomo/templates/docker-compose.yml.j2
@@ -5,7 +5,7 @@ services:
   matomo:
     container_name: matomo
     # We use the apache image as it allows us to reuse the existing nginx-proxy role as-is.
-    image: matomo:3-apache
+    image: matomo:4.2-apache
     restart: unless-stopped
     volumes:
       {% for volume_mapping in MATOMO_DOCKER_VOLUMES %}


### PR DESCRIPTION
This PR upgrades matomo from v3 to v4.2.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3809

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:
TBD

**Author notes and concerns**:

1. There might be some manual process to be done for database migration.

**Reviewers**
- [ ] @lgp171188 