### PR TITLE
Updates cert-manager playbook to use Python 3.6

### DIFF
--- a/playbooks/roles/cert-manager/tasks/main.yml
+++ b/playbooks/roles/cert-manager/tasks/main.yml
@@ -1,13 +1,22 @@
 ---
 
-- name: Download pip3
-  apt:
-    name: python3-pip
+- name: Add the `deadsnakes` PPA for getting Python3.6 on Ubuntu 16.04
+  apt_repository:
+    repo: 'ppa:deadsnakes/ppa'
 
-- name: Download pipenv
+- name: Download Python3.6
+  apt:
+    name: python3.6
+
+- name: Download pip3.6
+  shell:
+    cmd: curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6
+
+- name: Install pipenv to later install python dependencies and virtual environments.
   pip:
-    executable: pip3
     name: pipenv
+    executable: pip3.6
+  become: true
 
 - name: Download cert-manager
   git:


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

After the OVH server fire, we had to move the stage certificate manager to a new region.

However, when trying to run the playbook, it failed due to python 3.5.

This fixes that.

## Supporting information

* **Jira Tickets**: SE-4243

## Testing instructions

* Run the playbook on the stage certificate manager