### PR TITLE
[FAL-1676] Add MaxMind license key for the forums

### DIFF
--- a/playbooks/roles/discourse/templates/app.yml.j2
+++ b/playbooks/roles/discourse/templates/app.yml.j2
@@ -50,6 +50,8 @@ env:
   DISCOURSE_DB_NAME: {{ postgresql_discourse_dbname }}
   DISCOURSE_DB_HOST: {{ postgresql_discourse_host }}
 
+  DISCOURSE_MAXMIND_LICENSE_KEY: {{ discourse_maxmind_license_key }}
+
   ## TODO: The domain name this Discourse instance will respond to
   DISCOURSE_HOSTNAME: {{ discourse_hostname }}
 


### PR DESCRIPTION
This merge request is about adding the MaxMind license key to the Discourse configuration file.

https://github.com/open-craft/ansible-secrets/pull/253

**Jira tickets**

- [FAL-1676](https://tasks.opencraft.com/browse/FAL-1676)

**Testing instructions**

- Connect to [forum.opencraft.com](https://forum.opencraft.com)
- Go to the admin page
- Then "Users"
- Click on a random user
- Click on "IP lookup"
- Check that the IP location is found
- Do the same thing for [edxchange.opencraft.com](https://edxchange.opencraft.com)

**Reviewers**

- @swalladge 