### PR TITLE
[SE-4290] Restart celerybeat container for crafty-bot

### DIFF
--- a/playbooks/roles/crafty-bot/files/deploy.sh
+++ b/playbooks/roles/crafty-bot/files/deploy.sh
@@ -15,7 +15,7 @@ function executeComposeCommand() {
 
 function main() {
     executeComposeCommand "PULLING IMAGES" "pull";
-    executeComposeCommand "RESTARTING CONTAINERS" "up -d --no-deps django celeryworker"
+    executeComposeCommand "RESTARTING CONTAINERS" "up -d --no-deps django celeryworker celerybeat"
     executeCommand "CLEANING UP DOCKER SYSTEM" "docker system prune -f"
 }
 


### PR DESCRIPTION
At the moment, crafty bot does not recreate the celerybeat container. This means that the code running there does not get updated on the server. To fix this issue, we recreate the container just as we do with the django or celeryworker containers.

**Dependencies**: None

**Sandbox URL**: N/A

**Merge deadline**: ASAP

**Testing instructions**:

1. Run the playbook for crafty-bot by executing `ansible-playbook -u ubuntu -i hosts deploy/playbooks/crafty-bot.yml -l crafty-bot --extra-vars @group_vars/all/public.yml --extra-vars  @group_vars/prod/public.yml` from the secrets repo after updating the deploy submodule

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @nizarmah 