### PR TITLE
FAL-1773 Support custom jvm options for elasticsearch

### DIFF
--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -18,3 +18,8 @@ es_api_uri: "https://{{ elasticsearch_network_host }}:{{ elasticsearch_http_port
 elasticsearch_username: elastic
 elasticsearch_password: ""
 elasticsearch_keystore: ""
+
+# This should follow the format described in https://www.elastic.co/guide/en/elasticsearch/reference/current/jvm-options.html
+# It is templated out to 50-extra-jvm.options
+# Note that this is only supported by recent elasticsearch releases.
+elasticsearch_extra_jvm_options: ""

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -62,6 +62,16 @@
     mode: 0640
   notify: restart elasticsearch
 
+# this doesn't need to be conditionally templated, because old elasticsearch versions don't read from this file,
+# and an empty file is a valid file.
+- name: Elasticsearch extra jvm options
+  template:
+    src: 50-extra-jvm.options.j2
+    dest: /etc/elasticsearch/jvm.options.d/50-extra-jvm.options
+    group: elasticsearch
+    mode: 0640
+  notify: restart elasticsearch
+
 - name: Set bootstrap password
   shell: echo "{{ elasticsearch_password }}" | {{ elasticsearch_bin_dir }}/elasticsearch-keystore add -f -x 'bootstrap.password'
   when: elasticsearch_password|length > 0

--- a/playbooks/roles/elasticsearch/templates/50-extra-jvm.options.j2
+++ b/playbooks/roles/elasticsearch/templates/50-extra-jvm.options.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+{{ elasticsearch_extra_jvm_options }}


### PR DESCRIPTION
[FAL-1773](https://tasks.opencraft.com/browse/FAL-1773)

This allows overriding JVM options for elasticsearch, using the new jvm.options.d directory structure. See https://www.elastic.co/guide/en/elasticsearch/reference/current/jvm-options.html for syntax and more information.

It's not conditionally templated out, because empty files appear to be valid and old elasticsearch versions will just ignore these files.

**Test instructions**:

- set a value for `elasticsearch_extra_jvm_options`
- run this playbook
- verify that /etc/elasticsearch/jvm.options.d/50-extra-jvm.options is created successfully with the expected content

**Reviewers**:

- [x] @itsjeyd 