### PR TITLE
[FAL-1667] Pin jinja2 to a version that works with filebeat

### DIFF
--- a/requirements_ansible_2.8.17.txt
+++ b/requirements_ansible_2.8.17.txt
@@ -1,3 +1,4 @@
 ansible==2.8.17
 netaddr==0.7.19
 cryptography
+jinja2==2.11.3


### PR DESCRIPTION
The `filebeat` role requires a minimum version of `jinja2` in order to complete, due to the particular invocation of the `indent` filter.  Only tested this on the newer Ansible though.

Test instructions:

1. 