### PR TITLE
Update prometheus role to increase nofile limit for service

### DIFF
--- a/playbooks/roles/prometheus/tasks/main.yml
+++ b/playbooks/roles/prometheus/tasks/main.yml
@@ -16,4 +16,11 @@
     src: logrotate
     dest: /etc/logrotate.d/prometheus
 
+- name: set the nofile limit for prometheus service to a high number
+  copy:
+    content: |
+      [Service]
+      LimitNOFILE=infinity
+    dest: /etc/systemd/system/prometheus.service.d/override.conf
+
 - import_tasks: grafana.yml


### PR DESCRIPTION
The default nofile limit for prometheus is quite low, and the upstream change with the fix comes with a lot of other changes that we can't apply right now.

This will override the prometheus systemd unit to apply this limit without editing the existing file.