### PR TITLE
FAL-1750 Add playbook for mailing list host

### DIFF
--- a/playbooks/deploy-all.yml
+++ b/playbooks/deploy-all.yml
@@ -24,3 +24,4 @@
 - import_playbook: sprints.yml
 - import_playbook: crafty-bot.yml
 - import_playbook: matomo.yml
+- import_playbook: mailing-list.yml

--- a/playbooks/mailing-list.yml
+++ b/playbooks/mailing-list.yml
@@ -1,0 +1,7 @@
+---
+- name: Set up the mailing list instance
+  hosts: mailing-list
+  become: true
+  roles:
+    - role: common-server
+      tags: 'common-server'


### PR DESCRIPTION
[FAL-1750](https://tasks.opencraft.com/browse/FAL-1750)

This adds a playbook for mailing list tasks.  We'll need to add to this later when we set up mailman 3, etc.

**Test instructions**:

See https://github.com/open-craft/ansible-secrets/pull/267

Basically, this should set up the common server role on the new mailing list server.

**Reviewers**:

- [x] @toxinu 