### PR TITLE
[SE-4181] Install the Opencraft deb repository

### DIFF
--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -17,6 +17,17 @@
     state: link
     force: true
 
+- name: add Opencraft repository
+  apt_repository:
+    repo: "{{ COMMON_SERVER_OPENCRAFT_REPO }}"
+    state: present
+
+- name: add Opencraft repository key
+  apt_key:
+    keyserver: "{{ COMMON_SERVER_OPENCRAFT_REPO_KEY_SERVER }}"
+    id: "{{ COMMON_SERVER_OPENCRAFT_REPO_KEY_ID }}"
+    state: present
+
 - name: apt-get update, dist-upgrade and autoremove
   apt:
     update_cache: yes

--- a/playbooks/roles/common-server/defaults/main.yml
+++ b/playbooks/roles/common-server/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 COMMON_SERVER_HOSTNAME: "{{ inventory_hostname }}"
 COMMON_SERVER_HOSTNAME_SHORT: "{{ inventory_hostname_short }}"
 
@@ -49,6 +48,10 @@ COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: "{{ COMMON_SERVER_OPS_EMAIL }}"
 
 # Please think twice before setting it
 COMMON_SERVER_NO_BACKUPS: false
+
+COMMON_SERVER_OPENCRAFT_REPO: "deb http://debs.opencraft.com/ {{ ansible_distribution_release }} main"
+COMMON_SERVER_OPENCRAFT_REPO_KEY_SERVER: "keyserver.ubuntu.com"
+COMMON_SERVER_OPENCRAFT_REPO_KEY_ID: "59BDABBADA918972"
 
 COMMON_SERVER_DEPENDENCIES:
   - acl


### PR DESCRIPTION
This installs our custom repository and key by default.

For the moment, the repository only includes an updated chkrootkit for xenial, which fixes the periodical MongoDB DoS issue identified in SE-4147.  See https://github.com/open-craft/chkrootkit/pull/1 for the actual change.