### PR TITLE
[SE-4567] add clustered redis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "playbooks/roles/prometheus_redis_exporter_role"]
 	path = playbooks/roles/prometheus_redis_exporter_role
 	url = https://github.com/idealista/prometheus_redis_exporter_role
+[submodule "playbooks/roles/davidwittman.redis"]
+	path = playbooks/roles/davidwittman.redis
+	url = https://github.com/DavidWittman/ansible-redis.git

--- a/playbooks/deploy-all.yml
+++ b/playbooks/deploy-all.yml
@@ -15,6 +15,7 @@
 - import_playbook: postgres.yml
 - import_playbook: prometheus.yml
 - import_playbook: rabbitmq.yml
+- import_playbook: redis.yml
 - import_playbook: memcached.yml
 - import_playbook: custom-nginx-proxy.yml
 - import_playbook: relay.yml

--- a/playbooks/group_vars/redis/public.yml
+++ b/playbooks/group_vars/redis/public.yml
@@ -1,0 +1,12 @@
+# TARSNAP #####################################################################
+
+TARSNAP_BACKUP_FOLDERS: "{{ redis_dir }} /etc/letsencrypt"
+TARSNAP_BACKUP_PRE_SCRIPT: "{{ REDIS_SCRIPTS_DIR }}/{{ REDIS_BACKUP_COMMAND }}"
+
+# FILEBEAT ####################################################################
+
+filebeat_prospectors:
+  - fields:
+      type: "redis"
+    paths:
+      - "{{ REDIS_LOG_DIR }}/*.log"

--- a/playbooks/group_vars/redis/public.yml
+++ b/playbooks/group_vars/redis/public.yml
@@ -1,6 +1,6 @@
 # TARSNAP #####################################################################
 
-TARSNAP_BACKUP_FOLDERS: "{{ redis_dir }} /etc/letsencrypt"
+TARSNAP_BACKUP_FOLDERS: "{{ REDIS_BASE_DIR }} /etc/letsencrypt"
 TARSNAP_BACKUP_PRE_SCRIPT: "{{ REDIS_SCRIPTS_DIR }}/{{ REDIS_BACKUP_COMMAND }}"
 
 # FILEBEAT ####################################################################

--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -1,0 +1,23 @@
+---
+# Playbook for setting up a Redis cluster.
+
+- name: configure the master redis server
+  hosts: redis-master
+  roles:
+    - role: common-server
+      tags: 'common-server'
+
+    - role: davidwittman.redis
+      tags: 'davidwittman.redis'
+
+- name: configure redis slaves
+  hosts: redis-slave
+  vars:
+    # FIXME: This should come from somewhere else
+    - redis_slaveof: redis.opencraft.hosting 6379
+  roles:
+    - role: common-server
+      tags: 'common-server'
+
+    - role: davidwittman.redis
+      tags: 'davidwittman.redis'

--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -1,8 +1,8 @@
 ---
 # Playbook for setting up a Redis cluster.
 
-- name: configure the master redis server
-  hosts: redis-master
+- name: configure the primary redis server
+  hosts: redis-primary
   roles:
     - role: common-server
       tags: 'common-server'
@@ -10,11 +10,23 @@
     - role: davidwittman.redis
       tags: 'davidwittman.redis'
 
-- name: configure redis slaves
-  hosts: redis-slave
+- name: configure redis secondary replicas
+  hosts: redis-replica
   vars:
-    # FIXME: This should come from somewhere else
-    - redis_slaveof: redis.opencraft.hosting 6379
+    # Set in host_vars, e.g. "redis.opencraft.hosting {{ redis_port }}"
+    redis_slaveof: !!null
+    redis_slave_read_only: "yes"
+  roles:
+    - role: common-server
+      tags: 'common-server'
+
+    - role: davidwittman.redis
+      tags: 'davidwittman.redis'
+
+- name: configure redis sentinel
+  hosts: redis-sentinel
+  vars:
+    redis_sentinel: true
   roles:
     - role: common-server
       tags: 'common-server'

--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -3,6 +3,7 @@
 
 - name: configure the primary redis server
   hosts: redis-primary
+  become: true
   roles:
     - role: common-server
       tags: 'common-server'
@@ -12,6 +13,7 @@
 
 - name: configure redis secondary replicas
   hosts: redis-replica
+  become: true
   vars:
     # Set in host_vars, e.g. "redis.opencraft.hosting {{ redis_port }}"
     redis_slaveof: !!null
@@ -25,6 +27,7 @@
 
 - name: configure redis sentinel
   hosts: redis-sentinel
+  become: true
   vars:
     redis_sentinel: true
   roles:

--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -8,6 +8,9 @@
     - role: common-server
       tags: 'common-server'
 
+    - role: redis
+      tags: 'install-redis'
+
     - role: davidwittman.redis
       tags: 'davidwittman.redis'
 
@@ -22,6 +25,9 @@
     - role: common-server
       tags: 'common-server'
 
+    - role: redis
+      tags: 'install-redis'
+
     - role: davidwittman.redis
       tags: 'davidwittman.redis'
 
@@ -33,6 +39,9 @@
   roles:
     - role: common-server
       tags: 'common-server'
+
+    - role: redis
+      tags: 'install-redis'
 
     - role: davidwittman.redis
       tags: 'davidwittman.redis'

--- a/playbooks/roles/redis/README.md
+++ b/playbooks/roles/redis/README.md
@@ -1,0 +1,9 @@
+# Ansible role for deploying Redis
+
+This role deploys [Redis](https://redis.io/) as a single instance, not in cluster.
+
+This role uses DavidWittman's [redis role](https://galaxy.ansible.com/DavidWittman/redis) as that provides master-slave replication and sentinel out of the box.
+
+## Deployment
+
+The role can be run against a server with a vanilla Ubuntu 20.04 image.

--- a/playbooks/roles/redis/defaults/main.yml
+++ b/playbooks/roles/redis/defaults/main.yml
@@ -1,0 +1,18 @@
+REDIS_LOG_DIR: "/var/log/redis"
+REDIS_SCRIPTS_DIR: "/usr/local/sbin"
+REDIS_BACKUP_COMMAND: "redis-backup"
+
+redis_version: 6.2.4
+redis_checksum: "sha256:ba32c406a10fc2c09426e2be2787d74ff204eb3a2e496d87cff76a476b6ae16e"
+redis_verify_checksum: true
+redis_make_tls: true
+redis_timeout: 30
+redis_logfile: "{{ REDIS_LOG_DIR }}/redis.log"
+redis_maxmemory_policy: "allkeys-lru"
+
+# Filename cannot be a path
+redis_db_filename: "snapshot.rdb"
+
+# Additional configuration options
+# Use a block style scalar to add options
+redis_config_additional: ""

--- a/playbooks/roles/redis/defaults/main.yml
+++ b/playbooks/roles/redis/defaults/main.yml
@@ -1,18 +1,2 @@
-REDIS_LOG_DIR: "/var/log/redis"
 REDIS_SCRIPTS_DIR: "/usr/local/sbin"
 REDIS_BACKUP_COMMAND: "redis-backup"
-
-redis_version: 6.2.4
-redis_checksum: "sha256:ba32c406a10fc2c09426e2be2787d74ff204eb3a2e496d87cff76a476b6ae16e"
-redis_verify_checksum: true
-redis_make_tls: true
-redis_timeout: 30
-redis_logfile: "{{ REDIS_LOG_DIR }}/redis.log"
-redis_maxmemory_policy: "allkeys-lru"
-
-# Filename cannot be a path
-redis_db_filename: "snapshot.rdb"
-
-# Additional configuration options
-# Use a block style scalar to add options
-redis_config_additional: ""

--- a/playbooks/roles/redis/files/redis-backup
+++ b/playbooks/roles/redis/files/redis-backup
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+redis-cli save

--- a/playbooks/roles/redis/tasks/main.yml
+++ b/playbooks/roles/redis/tasks/main.yml
@@ -1,5 +1,17 @@
 ---
 
+# To be able to check the package checksum, the redis binary is built from
+# source, therefore we need the build delendencies to be installed. The
+# configuration also allows us to run multiple versions of redis on the same
+# servers, so this make sense.
+- name: install build dependencies
+  apt:
+    name: "{{item}}"
+  with_items:
+    - libssl-dev
+    - libjemalloc-dev
+    - build-essential
+
 - name: open redis port on the firewall
   ufw:
     rule: allow

--- a/playbooks/roles/redis/tasks/main.yml
+++ b/playbooks/roles/redis/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: open redis port on the firewall
+  ufw:
+    rule: allow
+    port: "{{ redis_port }}"
+    proto: tcp
+
+- name: add redis backup script
+  copy:
+    src: "{{ REDIS_BACKUP_COMMAND }}"
+    dest: "{{ REDIS_SCRIPTS_DIR }}/{{ REDIS_BACKUP_COMMAND }}"
+    mode: 0700


### PR DESCRIPTION
This PR moves the Redis role variables to common secrets, as we cannot set them by the `ansible-playbooks` repo's default's and we need to apply these variables to all Redis nodes.

**JIRA tickets**: https://tasks.opencraft.com/browse/FAL-2029

**Dependencies**:
* https://github.com/open-craft/ansible-playbooks/pull/229

**Merge deadline**: None

**Testing instructions**:

* Proofread as the node already provisioned

-- or --

* Run `terraform destroy` and `terraform apply` using the instructions in `https://gitlab.com/opencraft/dev/ocim-legacy-infrastructure/-/merge_requests/1`
* Check out https://github.com/open-craft/ansible-secrets/pull/283
* Update submodules to use https://github.com/open-craft/ansible-common-secrets/pull/27 and https://github.com/open-craft/ansible-playbooks/pull/229
* Run ansible playbook for Redis

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @pomegranited 