### PR TITLE
FAL-2014 Enable smtpd tls for mail server

### DIFF
--- a/playbooks/roles/mail/defaults/main.yml
+++ b/playbooks/roles/mail/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 
+# An optional block device to mount at /var/lib/mailman3
+# This device must be manually formatted to ext4 before running the playbook.
+MAILMAN_BLOCK_DEVICE: ""
+
 # The domain of the server.
 # This is used to configure the nginx proxy and reading certbot letsencrypt cert paths.
 MAILMAN_WEB_DOMAIN: "mailman.example.com"

--- a/playbooks/roles/mail/tasks/main.yml
+++ b/playbooks/roles/mail/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: mount /var/lib/mailman3/
+  mount:
+    name: /var/lib/mailman3
+    src: "{{ MAILMAN_BLOCK_DEVICE }}"
+    fstype: ext4
+    state: mounted
+  when: MAILMAN_BLOCK_DEVICE|string
+
 - name: mailman3 packages
   apt:
     name:

--- a/playbooks/roles/mail/templates/postfix-main.cf.j2
+++ b/playbooks/roles/mail/templates/postfix-main.cf.j2
@@ -40,3 +40,9 @@ relay_domains =
     hash:/var/lib/mailman3/data/postfix_domains
 
 smtpd_recipient_restrictions = permit_mynetworks,reject_unauth_destination
+
+smtpd_tls_cert_file = /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/fullchain.pem
+smtpd_tls_key_file = /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/privkey.pem
+smtpd_tls_security_level = may
+smtpd_tls_session_cache_database = btree:${queue_directory}/smtpd_scache
+smtp_tls_session_cache_database = btree:${queue_directory}/smtp_scache

--- a/playbooks/roles/postfix/templates/main.cf
+++ b/playbooks/roles/postfix/templates/main.cf
@@ -14,7 +14,7 @@ smtpd_sasl_local_domain = $myhostname
 smtpd_sasl_security_options = noanonymous
 smtpd_sasl_auth_enable = yes
 
-# Relay mail to opencraft.com directly to mail.plebia.org
+# Relay mail to internal domains directly to the configured internal mail host
 relay_domains = {{ POSTFIX_INTERNAL_DOMAIN }} $mydestination
 relay_transport = relay:{{ POSTFIX_INTERNAL_MAIL_HOST }}
 
@@ -42,7 +42,7 @@ smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_loglevel = 1
 smtpd_tls_received_header = yes
 
-# Vaurious settings from the Ubuntu default configuration
+# Various settings from the Ubuntu default configuration
 biff = no
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases


### PR DESCRIPTION
[FAL-2014](https://tasks.opencraft.com/browse/FAL-2014)

Also fix some minor typos and wording for the relay server postfix config

**Test instructions**:

- this has been deployed to the relay and new mail server for testing
- check for correctness (new smtpd config should make sense)

**Reviewers**:

- [ ] @toxinu 