### PR TITLE
BB-4426: Replace networking with netplan configuration WIP

### DIFF
--- a/playbooks/roles/common-server-init/tasks/networking.yml
+++ b/playbooks/roles/common-server-init/tasks/networking.yml
@@ -8,8 +8,6 @@
       template:
         src: network/interfaces.d/floating-ip.cfg
         dest: /etc/network/interfaces.d/floating-ip.cfg
-        src: netplan/floating-ip.yaml
-        dest: /etc/netplan/floating-ip.yaml
         owner: root
         group: root
         mode: 0644

--- a/playbooks/roles/common-server-init/tasks/networking.yml
+++ b/playbooks/roles/common-server-init/tasks/networking.yml
@@ -1,13 +1,15 @@
 ---
 
-- name: Add network interface for floating IP
-  when: COMMON_FLOATING_INTERFACE_NAME and COMMON_FLOATING_IP
-  block:
+- name: Add network interface for floating IP (Xenial, Bionic)
+  when: COMMON_FLOATING_INTERFACE_NAME and COMMON_FLOATING_IP and ansible_distribution_release in ["xenial", "bionic"]
 
+  block:
     - name: Add floating IP as network interface alias
       template:
         src: network/interfaces.d/floating-ip.cfg
         dest: /etc/network/interfaces.d/floating-ip.cfg
+        src: netplan/floating-ip.yaml
+        dest: /etc/netplan/floating-ip.yaml
         owner: root
         group: root
         mode: 0644
@@ -25,6 +27,22 @@
 
     - name: Bring up new interface
       command: "ifup {{ COMMON_FLOATING_INTERFACE_NAME }}"
+
+- name: Add network interface for floating IP using netplan (Focal)
+  when: COMMON_FLOATING_INTERFACE_NAME and COMMON_FLOATING_IP and ansible_distribution_release == "focal"
+  block:
+
+    - name: Add floating IP as network interface alias
+      template:
+        src: netplan/floating-ip.yaml
+        dest: /etc/netplan/floating-ip.yaml
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Apply changes using netplan
+      command: "netplan apply"
+      become: true
 
 - name: Add fallback DNS servers to /etc/dhcp/dhclient.conf.
   lineinfile:

--- a/playbooks/roles/common-server-init/templates/netplan/floating-ip.yaml
+++ b/playbooks/roles/common-server-init/templates/netplan/floating-ip.yaml
@@ -1,0 +1,12 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    {{ COMMON_FLOATING_INTERFACE_NAME }}:
+      dhcp4: yes
+      dhcp6: yes
+      addresses:
+        # Setting the floating IP address + netmask (255.255.255.255)
+        - "{{ COMMON_FLOATING_IP }}/32":
+            lifetime: 0
+            label: "{{ COMMON_FLOATING_INTERFACE_NAME }}:1"

--- a/playbooks/roles/common-server-init/templates/netplan/floating-ip.yaml
+++ b/playbooks/roles/common-server-init/templates/netplan/floating-ip.yaml
@@ -7,6 +7,4 @@ network:
       dhcp6: yes
       addresses:
         # Setting the floating IP address + netmask (255.255.255.255)
-        - "{{ COMMON_FLOATING_IP }}/32":
-            lifetime: 0
-            label: "{{ COMMON_FLOATING_INTERFACE_NAME }}:1"
+        - "{{ COMMON_FLOATING_IP }}/32"


### PR DESCRIPTION
This PR replaces `networking` for `netplan` configuration and makes this playbook compatible with Ubuntu 20.04.
I don't want to keep multiple release version handling for simplicity, so this should only be merged once we have the bare-metal servers on Focal.

**Testing instructions:**
I've already applied this playbook on our spare baremetal server.

1. SSH into the server using the DNS record, IP, and failover IP address.
2. Check the network configuration with `ifconfig`.

**Notes:**
Since there's some secrets involved in testing this, I'll leave a comment in the internal ticket.

**Reviewers:**
- [ ] @0x29a 
- [x] @lgp171188 

