### PR TITLE
[SE-4582] remove cache_valid_time to update cache

### DIFF
--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -32,7 +32,6 @@
   apt:
     update_cache: yes
     upgrade: dist
-    cache_valid_time: 43200
     autoremove: yes
 
 - name: Install dependencies


### PR DESCRIPTION
## Description

Based on the documentation and implementation, it seems that the cache is updated if and only if the deadline set by `cache_valid_time` is in the past. Meaning that if we set both `cache_valid_time` and `update_cache` it won't be updated.

Although the changes that were intended to update the cache were added ~3 years ago, we never needed to update keys before – I guess. That's the reason why it did not break before. After the new changes were introduced lately to add the Opencraft repository, we started to face the issue.

## Test instructions
To validate the idea, I just removed the `cache_valid_time` parameter from the task and it works nicely.