### PR TITLE
fix: remove redis_slave: !!null from playbook

### DIFF
--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -18,8 +18,7 @@
   hosts: redis-replica
   become: true
   vars:
-    # Set in host_vars, e.g. "redis.opencraft.hosting {{ redis_port }}"
-    redis_slaveof: !!null
+    # Set redis_slaveof in host_vars, e.g. "redis.opencraft.hosting {{ redis_port }}"
     redis_slave_read_only: "yes"
   roles:
     - role: common-server


### PR DESCRIPTION
Wasn't able to override this with the host vars with this in the playbook vars.

See https://github.com/open-craft/ansible-secrets/pull/290 for test instructions.

**Reviewer**

- [ ] @swalladge 