### PR TITLE
Fix copy-pasted description of prometheus alert.

### DIFF
--- a/playbooks/group_vars/prometheus/public.yml
+++ b/playbooks/group_vars/prometheus/public.yml
@@ -115,8 +115,8 @@ prometheus_rules:
         severity: "warning"
         environment: "[[ $labels.environment ]]"
       annotations:
-        summary: "Instance [[ $labels.node ]] ([[ $labels.instance ]]) http response time high."
-        description: "HTTP response time of [[ $labels.node ]] ([[ $labels.instance ]]) of job [[ $labels.job ]] has been above {{ PROMETHEUS_ALERT_HTTP_RESPONSE_TIME_THRESHOLD }} for 5 minutes."
+        summary: "Instance [[ $labels.node ]] ([[ $labels.instance ]]) http errors high."
+        description: "HTTP error ratio on [[ $labels.node ]] ([[ $labels.instance ]]) of job [[ $labels.job ]] has been above {{ PROMETHEUS_ALERT_HTTP_RESPONSE_FRONTEND_ERROR_THRESHOLD }} for 5 minutes."
   - name: "MySQLRules"
     rules:
     - alert: "mysql_down"


### PR DESCRIPTION
This fixes the error message of `haproxy_frontend_request_errors_high` which seems to have been copy-pasted from `haproxy_backend_response_time_high` and never properly updated.

**Testing instructions**:

1. Log into https://prometheus.net.opencraft.hosting/alerts
2. Click on `haproxy_frontend_request_errors_high` and verify that the summary and description templates looks correct.