### PR TITLE
Update HAProxy frontend error alert condition.

### DIFF
--- a/playbooks/group_vars/prometheus/public.yml
+++ b/playbooks/group_vars/prometheus/public.yml
@@ -33,7 +33,7 @@ PROMETHEUS_ALERT_MEMORY_THRESHOLD: 90
 PROMETHEUS_ALERT_DISK_SPACE_THRESHOLD: 80
 
 PROMETHEUS_ALERT_HTTP_RESPONSE_TIME_THRESHOLD: 1
-PROMETHEUS_ALERT_HTTP_RESPONSE_FRONTEND_ERROR_THRESHOLD: 70
+PROMETHEUS_ALERT_HTTP_RESPONSE_FRONTEND_ERROR_THRESHOLD: 35
 
 OCIM_QUEUE_REDIS_KEY: null
 PROMETHEUS_ALERT_OCIM_QUEUE_SIZE_THRESHOLD: null
@@ -109,7 +109,7 @@ prometheus_rules:
         summary: "Instance [[ $labels.node ]] ([[ $labels.instance ]]) http response time high."
         description: "HTTP response time of [[ $labels.node ]] ([[ $labels.instance ]]) of job [[ $labels.job ]] has been above {{ PROMETHEUS_ALERT_HTTP_RESPONSE_TIME_THRESHOLD }} for 5 minutes."
     - alert: "haproxy_frontend_request_errors_high"
-      expr: "(100 * (haproxy_frontend_request_errors_total/haproxy_frontend_http_requests_total)) > {{ PROMETHEUS_ALERT_HTTP_RESPONSE_FRONTEND_ERROR_THRESHOLD }}"
+      expr: "(100 * (rate(haproxy_frontend_request_errors_total{frontend='fe_https'}[5m])/rate(haproxy_frontend_http_requests_total{frontend='fe_https'}[5m]))) > {{ PROMETHEUS_ALERT_HTTP_RESPONSE_FRONTEND_ERROR_THRESHOLD }}"
       for: "5m"
       labels:
         severity: "warning"


### PR DESCRIPTION
This makes the prometheus query that we use for the frontend error alert more predictable since it uses 5 minute rates instead of the plain accumulative request and error counts.

We're currently querying `haproxy_frontend_request_errors_total / haproxy_frontend_http_requests_total` but both of these variables are cumulative. The number of both of these variables keeps growing more or less monotonically until it is reset when the node exporter flushes its internal value.

This doesn't produce very reliable results, especially around the times when values get flushed.

This PR switches to using a 5 minute rate using the ratio of the rates of these two variables. It also limits the query to the `fe_https` backend only. There are two other backends: `stats`, which is internal only and has a very low number of requests, and `fe_http`, which I'm not really sure what it's used for, but it also has very low and unstable traffic, and produces false alerts.

**Testing instructions**:

- Look at the `haproxy_frontend_request_errors_high` on the [prometheus alerts page](https://prometheus.net.opencraft.hosting/alerts).
- Verify that the error condition looks correct.
- Explore the [results of the alert query](https://prometheus.net.opencraft.hosting/graph?g0.range_input=1h&g0.expr=(100%20*%20(rate(haproxy_frontend_request_errors_total%7Bfrontend%3D%22fe_https%22%7D%5B5m%5D)%20%2F%20rate(haproxy_frontend_http_requests_total%7Bfrontend%3D%22fe_https%22%7D%5B5m%5D)))%20%3E%2050&g0.tab=1) and play with the threshold (set to `50`) to see how much you can lower it before it starts returning results.

**Reviewer**:

- [ ] @toxinu 