### PR TITLE
FAL-2085 Increase tmpreaper runtime limit by default

### DIFF
--- a/playbooks/roles/common-server-init/defaults/main.yml
+++ b/playbooks/roles/common-server-init/defaults/main.yml
@@ -1,1 +1,5 @@
 COMMON_SERVER_INSTALL_NGINX: true
+
+# Default tmpreaper runtime limit is 55 seconds.
+# This often isn't enough, so increase by default.
+TMPREAPER_RUNTIME: '110'

--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -39,11 +39,10 @@
     name: "{{ COMMON_SERVER_DEPENDENCIES }}"
     state: present
 
-- name: Activate tmpreaper
-  lineinfile:
+- name: tmpreaper is configured
+  template:
+    src: tmpreaper.conf
     dest: /etc/tmpreaper.conf
-    regexp: "^SHOWWARNING=true"
-    state: absent
 
 - name: Copy security update check script
   copy:

--- a/playbooks/roles/common-server-init/templates/tmpreaper.conf
+++ b/playbooks/roles/common-server-init/templates/tmpreaper.conf
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+# docs: `man 5 tmpreaper` or https://manpages.ubuntu.com/manpages/focal/man5/tmpreaper.conf.5.html
+
+TMPREAPER_PROTECT_EXTRA=''
+TMPREAPER_DIRS='/tmp/.'
+TMPREAPER_DELAY='256'
+TMPREAPER_ADDITIONALOPTIONS='--runtime={{ TMPREAPER_RUNTIME }}'


### PR DESCRIPTION
In the process, refactor tmpreaper config tasks to use a template,
because we can no longer neatly use the lineinfile method.

**Test instructions**:

- run this playbook against ocim stage and verify the new task shows as unchanged (this has already been run on ocim stage) - note that ocim stage is now running focal, so you'll need the ansible 2.8 requirements set.
- ssh into ocim stage and check that /etc/tmpreaper.conf is as expected and has the expected runtime limit override
- verify that we aren't getting pinged on ops about `error: run time exceeded!` for tmpreaper on ocim stage

**Reviewers**:

- [ ] @mtyaka 