### PR TITLE
FAL-2116 Add support for configuring postfix header_checks

### DIFF
--- a/playbooks/roles/mail/defaults/main.yml
+++ b/playbooks/roles/mail/defaults/main.yml
@@ -50,3 +50,7 @@ POSTFIX_TRANSPORT_CONTENT: ""
 # This is templated out as the contents of the postfix aliases file.
 # See http://www.postfix.org/aliases.5.html for syntax.
 POSTFIX_ALIASES_CONTENT: ""
+
+# This is templated out as the contents of the postfix header_checks file.
+# See http://www.postfix.org/header_checks.5.html for syntax.
+POSTFIX_HEADER_CHECKS_CONTENT: ""

--- a/playbooks/roles/mail/tasks/main.yml
+++ b/playbooks/roles/mail/tasks/main.yml
@@ -20,6 +20,7 @@
   apt:
     name:
       - "postfix"
+      - "postfix-pcre"  # required for header_checks = pcre:...
   notify:
     - "reload postfix"
 
@@ -108,6 +109,13 @@
     dest: "/etc/aliases"
   notify:
     - "newaliases"
+
+- name: Postfix header_checks
+  template:
+    src: "postfix-header_checks.j2"
+    dest: "/etc/postfix/header_checks"
+  notify:
+    - "reload postfix"
 
 - name: Postfix is configured
   template:

--- a/playbooks/roles/mail/templates/postfix-header_checks.j2
+++ b/playbooks/roles/mail/templates/postfix-header_checks.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+# http://www.postfix.org/header_checks.5.html
+# This is templated out to /etc/postfix/header_checks
+
+{{ POSTFIX_HEADER_CHECKS_CONTENT }}

--- a/playbooks/roles/mail/templates/postfix-main.cf.j2
+++ b/playbooks/roles/mail/templates/postfix-main.cf.j2
@@ -41,6 +41,8 @@ relay_domains =
 
 smtpd_recipient_restrictions = permit_mynetworks,reject_unauth_destination
 
+header_checks = pcre:/etc/postfix/header_checks
+
 smtpd_tls_cert_file = /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/fullchain.pem
 smtpd_tls_key_file = /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/privkey.pem
 smtpd_tls_security_level = may


### PR DESCRIPTION
https://tasks.opencraft.com/browse/FAL-2116

As in title.

**Test instructions**:

- run the playbook
- verify that /etc/postfix/header_checks is templated out as expected

**Reviewers**:

- [ ] TODO