### PR TITLE
[BB-4495] Fix the services VM elasticsearch installation issue in our ansible-playbooks repo

### DIFF
--- a/playbooks/group_vars/elasticsearch/public.yml
+++ b/playbooks/group_vars/elasticsearch/public.yml
@@ -2,7 +2,7 @@
 
 # ELASTICSEARCH ###############################################################
 
-elasticsearch_repo: "deb http://packages.elastic.co/elasticsearch/1.5/debian stable main"
+elasticsearch_repo: "deb [trusted=yes] http://packages.elastic.co/elasticsearch/1.5/debian stable main"
 elasticsearch_package: "elasticsearch=1.5.2"
 elasticsearch_network_host: 0.0.0.0
 elasticsearch_http_port: 9200

--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -19,6 +19,8 @@ elasticsearch_username: elastic
 elasticsearch_password: ""
 elasticsearch_keystore: ""
 
+elasticsearch_cfg_extra: ""
+
 # This should follow the format described in https://www.elastic.co/guide/en/elasticsearch/reference/current/jvm-options.html
 # It is templated out to 50-extra-jvm.options
 # Note that this is only supported by recent elasticsearch releases.

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -62,6 +62,8 @@
     mode: 0640
   notify: restart elasticsearch
 
+# void creating the file if there is no extra jvm options
+# old es versions (v1.5) doesn't use this file
 - name: Elasticsearch extra jvm options
   template:
     src: 50-extra-jvm.options.j2

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -62,8 +62,6 @@
     mode: 0640
   notify: restart elasticsearch
 
-# this doesn't need to be conditionally templated, because old elasticsearch versions don't read from this file,
-# and an empty file is a valid file.
 - name: Elasticsearch extra jvm options
   template:
     src: 50-extra-jvm.options.j2
@@ -71,6 +69,7 @@
     group: elasticsearch
     mode: 0640
   notify: restart elasticsearch
+  when: elasticsearch_extra_jvm_options|length > 0
 
 - name: Set bootstrap password
   shell: echo "{{ elasticsearch_password }}" | {{ elasticsearch_bin_dir }}/elasticsearch-keystore add -f -x 'bootstrap.password'


### PR DESCRIPTION
## Description

This PR fixes issues installing Elasticsearch v1.5 in Ubuntu 20.04 vms.

## Supporting information

https://tasks.opencraft.com/browse/BB-4495

## Testing instructions

- Pull this PR
- Provision a Ubuntu 20.04 VM with the `elasticsearch.yml` playbook.

## Deadline

ASAP

## Other information

**Reviewer** 
- [x] @farhaanbukhsh 
- [ ] @giovannicimolin 