### PR TITLE
[SE-4608] set apt preferences to  prioritize the opencraft repository

### DIFF
--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -28,6 +28,14 @@
     id: "{{ COMMON_SERVER_OPENCRAFT_REPO_KEY_ID }}"
     state: present
 
+- name: set apt preferences to prioritize the opencraft repo
+  copy:
+    content: |
+            Package: chkrootkit
+            Pin: Origin "debs.opencraft.com"
+            Pin-Priority: 1001
+    dest: /etc/apt/preferences.d/opencraft
+
 - name: apt-get update, dist-upgrade and autoremove
   apt:
     update_cache: yes

--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -32,7 +32,7 @@
   copy:
     content: |
             Package: chkrootkit
-            Pin: Origin "debs.opencraft.com"
+            Pin: Origin "{{ COMMON_SERVER_OPENCRAFT_REPO_DOMAIN }}"
             Pin-Priority: 1001
     dest: /etc/apt/preferences.d/opencraft
 

--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -17,15 +17,15 @@
     state: link
     force: true
 
-- name: add Opencraft repository
-  apt_repository:
-    repo: "{{ COMMON_SERVER_OPENCRAFT_REPO }}"
-    state: present
-
 - name: add Opencraft repository key
   apt_key:
     keyserver: "{{ COMMON_SERVER_OPENCRAFT_REPO_KEY_SERVER }}"
     id: "{{ COMMON_SERVER_OPENCRAFT_REPO_KEY_ID }}"
+    state: present
+
+- name: add Opencraft repository
+  apt_repository:
+    repo: "{{ COMMON_SERVER_OPENCRAFT_REPO }}"
     state: present
 
 - name: set apt preferences to prioritize the opencraft repo

--- a/playbooks/roles/common-server/defaults/main.yml
+++ b/playbooks/roles/common-server/defaults/main.yml
@@ -52,6 +52,7 @@ COMMON_SERVER_NO_BACKUPS: false
 COMMON_SERVER_OPENCRAFT_REPO: "deb http://debs.opencraft.com/ {{ ansible_distribution_release }} main"
 COMMON_SERVER_OPENCRAFT_REPO_KEY_SERVER: "keyserver.ubuntu.com"
 COMMON_SERVER_OPENCRAFT_REPO_KEY_ID: "59BDABBADA918972"
+COMMON_SERVER_OPENCRAFT_REPO_DOMAIN: "debs.opencraft.com"
 
 COMMON_SERVER_DEPENDENCIES:
   - acl

--- a/playbooks/roles/common-server/defaults/main.yml
+++ b/playbooks/roles/common-server/defaults/main.yml
@@ -49,10 +49,10 @@ COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: "{{ COMMON_SERVER_OPS_EMAIL }}"
 # Please think twice before setting it
 COMMON_SERVER_NO_BACKUPS: false
 
-COMMON_SERVER_OPENCRAFT_REPO: "deb http://debs.opencraft.com/ {{ ansible_distribution_release }} main"
+COMMON_SERVER_OPENCRAFT_REPO_DOMAIN: "debs.opencraft.com"
+COMMON_SERVER_OPENCRAFT_REPO: "deb http://{{ COMMON_SERVER_OPENCRAFT_REPO_DOMAIN }}/ {{ ansible_distribution_release }} main"
 COMMON_SERVER_OPENCRAFT_REPO_KEY_SERVER: "keyserver.ubuntu.com"
 COMMON_SERVER_OPENCRAFT_REPO_KEY_ID: "59BDABBADA918972"
-COMMON_SERVER_OPENCRAFT_REPO_DOMAIN: "debs.opencraft.com"
 
 COMMON_SERVER_DEPENDENCIES:
   - acl


### PR DESCRIPTION
This change prioritizes using the opencraft repository for the chkrootkit package. This way future updates to the main release wouldn't prioritize the main release over the opencraft one.