### PR TITLE
FAL-2284 Remove listen on port 80 for mailman3 nginx proxy

### DIFF
--- a/playbooks/roles/mail/templates/mailman3-nginx-proxy.conf.j2
+++ b/playbooks/roles/mail/templates/mailman3-nginx-proxy.conf.j2
@@ -5,17 +5,6 @@ upstream mailman3 {
 }
 
 server {
-    listen 80;
-    listen [::]:80;
-    server_name {{ MAILMAN_WEB_DOMAIN }};
-    server_tokens off;
-
-    return 301 https://$server_name$request_uri;
-    access_log /var/log/nginx/mailman3-access.log combined;
-    error_log /var/log/nginx/mailman3-error.log;
-}
-
-server {
     listen 443;
     listen [::]:443;
     server_name {{ MAILMAN_WEB_DOMAIN }};


### PR DESCRIPTION
[FAL-2284](https://tasks.opencraft.com/browse/FAL-2284)

Only the common-server should listen on port 80,
because it uses that to intercept requests to the well-known acme-challenge location
for certbot renewals.
This server block was blocking certbot renewals by sending the acme-challenge
requests to mailman, instead of letting the common-server server block handle it.

By removing this server block, we fix certbot renewals on the mail server instance.

**Test instructions**:

- verify that certbot renews successfully on mail.opencraft.com (this will not be possible for a few days, unless you run a force renewal, because the certs were renewed today)
- alternatively, run `curl mail.opencraft.com/.well-known/acme-challenge/test` and verify you get a 404, instead of a redirect to https://...
- run `ansible-playbook -vvv ./deploy/playbooks/deploy-all.yml -l mail -t mail` from ansible-secrets and verify that no changes were needed (this playbook has already been run on mail.opencraft.com)
- visit http://mail.opencraft.com/postorius/lists/ and verify the web mailman interface is still working

**Reviewers**:

- [x] @itsjeyd 