### PR TITLE
FAL-2311 Run the sanity checker every 10 minutes

### DIFF
--- a/playbooks/roles/sanity-checker/tasks/main.yml
+++ b/playbooks/roles/sanity-checker/tasks/main.yml
@@ -18,5 +18,5 @@
 - name: install sanity checks crontab
   cron:
     job: "{{ SANITY_CHECK_SCRIPT_LOCATION }} {{ SANITY_CHECK_CONFIG }} > /dev/null 2>&1"
-    minute: "10,20,30,40,50"
+    minute: "1,11,21,31,41,51"
     name: "sanity checker for: {{ SANITY_CHECK_SUBJECT }}"


### PR DESCRIPTION
[FAL-2311](https://tasks.opencraft.com/browse/FAL-2311)

Previously, it was _supposed_ to run every 10 minutes,
but it skipped '0', so there was a 20min gap every hour,
which can cause false positives for snitches.

Also don't use the `*/10` syntax,
because we want to offset it by one minute,
to avoid issues where everything happens on a minute divisible by 10.

**Test instructions**:

- run this on a server that has the sanity checker configured
- wait an hour
- verify that it runs every 10 minutes, starting at 1 minute past the hour

**Reviewers**:

- [x] @clemente 