### PR TITLE
[BB-4567] fix: pass the apt packages list directly to the apt module

### DIFF
--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -1,8 +1,7 @@
 - name: Install prerequisites
   apt:
-    name: "{{ item }}"
+    name: "{{ pyenv_prerequisite_packages }}"
     state: present
-  loop: "{{ pyenv_prerequisite_packages }}"
 
 - name: Ensure that the "{{ pyenv_home }}" directory is present and has the right permissions
   file:


### PR DESCRIPTION
The previous implementation used the loop keyword which installed the
provided packages one at a time and hence was inefficient.