### PR TITLE
fix: increase nginx max_body_size for mailman [BB-4955]

### DIFF
--- a/playbooks/roles/mail/templates/mailman3-nginx-proxy.conf.j2
+++ b/playbooks/roles/mail/templates/mailman3-nginx-proxy.conf.j2
@@ -10,6 +10,8 @@ server {
     server_name {{ MAILMAN_WEB_DOMAIN }};
     server_tokens off;
 
+    client_max_body_size 10M;
+
     ssl on;
     ssl_certificate /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/privkey.pem;


### PR DESCRIPTION
The default size (1M) was causing lots of 413 errors.

I thought about making this configurable, but we're not resuing this role, so we can keep 10M as a default value for now.