### PR TITLE
FAL-1993 Update filebeat configuration for version 7

### DIFF
--- a/playbooks/roles/filebeat/defaults/main.yml
+++ b/playbooks/roles/filebeat/defaults/main.yml
@@ -2,7 +2,6 @@
 
 filebeat_elastic_apt_pin: 500
 filebeat_config_dir: /etc/filebeat
-filebeat_registry_file: /var/lib/filebeat/registry
 
 filebeat_ca_cert: ""
 filebeat_cert: ""

--- a/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -1,7 +1,5 @@
 filebeat:
-  registry_file: "{{ filebeat_registry_file }}"
-
-  prospectors:
+  inputs:
     {% for prospector in filebeat_prospectors %}
 - {{ filebeat_common_prospector | combine(prospector, recursive=True) | to_nice_yaml | indent(width=6) }}
     {% endfor %}


### PR DESCRIPTION
Rename `prospectors` to `inputs`.
`prospectors` was deprecated in version 6.3, and removed in a later version,
so we can rename without breaking any hosts now (all seem to be 6.8 or 7.*).

Remove `registry_file`.
This was a backwards incompatible change somewhere between version 6.8 and 7.15.
We aren't overriding the default anywhere, so we can simply remove the option altogether.

**Test instructions**:

- deploy [this ansible task](https://github.com/open-craft/ansible-playbooks/blob/5415bde549f04c2a182a0ab6115f939a9b54f945/playbooks/roles/filebeat/tasks/main.yml#L36-L40) to an instance that uses filebeat (eg. logs.opencraft.com; this patch has already been used to deploy there)
- verify that filebeat runs successfully
- verify the filebeat config file looks as expected (`/etc/filebeat/filebeat.yml`)

