### PR TITLE
FAL-2496 fix: ensures curator role can delete old filebeat indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *~
 __pycache__
 molecule/*/*.log
+
+*.swp

--- a/playbooks/roles/curator/defaults/main.yml
+++ b/playbooks/roles/curator/defaults/main.yml
@@ -1,9 +1,19 @@
 ---
 
 curator_config_dir: /etc/curator
+curator_user: curator
+curator_group: curator
 
 curator_elasticsearch_hosts:
   - 127.0.0.1
 curator_elasticsearch_port: 9200
+curator_timeout: 30
 
+curator_elasticsearch_username: curator
+curator_elasticsearch_password: !!null
+
+curator_use_ssl: False
+curator_log_level: ERROR
+
+curator_delete_indices_prefix: filebeat
 curator_delete_indices_days: 5

--- a/playbooks/roles/curator/tasks/main.yml
+++ b/playbooks/roles/curator/tasks/main.yml
@@ -12,22 +12,94 @@
   apt:
     name: elasticsearch-curator
 
-- name: Create curator config directory
+- name: Create Curator config directory
   file:
     path: "{{ curator_config_dir }}"
     state: directory
     mode: 0750
 
+- name: Create Curator system group
+  group:
+    name: "{{ curator_group }}"
+    state: present
+
+- name: Create Curator system user
+  user:
+    name: "{{ curator_user }}"
+    group: "{{ curator_group }}"
+    home: "{{ curator_config_dir }}"
+    system: yes
+    state: present
+
+- name: Install Elasticsearch Certificates
+  copy:
+    content: "{{ elasticsearch_ca }}"
+    dest: "{{ curator_config_dir }}/elasticsearch-ca.pem"
+    owner: "{{ curator_user }}"
+    group: "{{ curator_group }}"
+    mode: 0640
+  when: elasticsearch_ca is defined
+
 - name: Install Curator configuration files
   template:
     src: "{{ item }}.j2"
     dest: "{{ curator_config_dir }}/{{ item }}"
+    owner: "{{ curator_user }}"
+    group: "{{ curator_group }}"
   with_items:
     - action.yml
     - config.yml
 
+- name: Change Curator home owner
+  file:
+    path: "{{ curator_config_dir }}"
+    owner: "{{ curator_user }}"
+    group: "{{ curator_group }}"
+    state: directory
+
+- name: Add curator elasticsearch role and user
+  include_tasks: roles/elasticsearch/tasks/create_user_roles.yml
+  vars:
+    elasticsearch_create_roles:
+    - name: curator_writer
+      permissions: |-
+        {
+          "cluster" : [
+            "monitor",
+          ],
+          "indices" : [
+            {
+              "names" : [
+                "{{ curator_delete_indices_prefix }}*"
+              ],
+              "privileges" : [
+                "manage",
+                "delete_index",
+                "delete",
+                "write",
+                "read"
+              ],
+              "allow_restricted_indices" : false
+            }
+          ],
+          "applications" : [],
+          "run_as" : [],
+          "metadata" : {
+            "version" : 1
+          },
+          "transient_metadata" : {
+            "enabled" : true
+          }
+        }
+    elasticsearch_create_users:
+    - username: "{{ curator_elasticsearch_username }}"
+      password: "{{ curator_elasticsearch_password }}"
+      roles:
+      - curator_writer
+
 - name: Install Curator cron job
   cron:
-    name: "Delete indices older than {{ curator_delete_indices_days }} days"
+    name: "Delete {{ curator_delete_indices_prefix }}* indices older than {{ curator_delete_indices_days }} days"
     job: "curator --config {{ curator_config_dir }}/config.yml {{ curator_config_dir }}/action.yml"
     special_time: daily
+    user: "{{ curator_user }}"

--- a/playbooks/roles/curator/templates/action.yml.j2
+++ b/playbooks/roles/curator/templates/action.yml.j2
@@ -8,8 +8,9 @@ actions:
       continue_if_exception: True
       timeout_override: 300
     filters:
-      - filtertype: kibana
-        exclude: true
+      - filtertype: pattern
+        kind: prefix
+        value: {{ curator_delete_indices_prefix }}
       - filtertype: age
         source: creation_date
         direction: older

--- a/playbooks/roles/curator/templates/config.yml.j2
+++ b/playbooks/roles/curator/templates/config.yml.j2
@@ -2,6 +2,15 @@
 client:
   hosts: {{ curator_elasticsearch_hosts }}
   port: {{ curator_elasticsearch_port }}
-
+  timeout: {{ curator_timeout }}
+  use_ssl: {{ curator_use_ssl }}
+{% if curator_use_ssl %}
+  ssl_no_validate: False
+  certificate: {{ curator_config_dir }}/elasticsearch-ca.pem
+{% endif %}
+{% if curator_elasticsearch_password %}
+  username: {{ curator_elasticsearch_username }}
+  password: {{ curator_elasticsearch_password }}
+{% endif %}
 logging:
-  loglevel: ERROR
+  loglevel: {{ curator_log_level }}

--- a/playbooks/roles/elasticsearch/README.md
+++ b/playbooks/roles/elasticsearch/README.md
@@ -42,7 +42,7 @@ We will also need to set `elasticsearch_ca` with the contents of `kibana/elastic
 cat kibana/elasticsearch-ca.pem
 ```
 
-We will also need to set passwords for 3 separate ansible variables: `logstash_elasticsearch_password`, `kibana_elasticsearch_password`, and `elasticsearch_password`.
+We will also need to set passwords for 4 separate ansible variables: `logstash_elasticsearch_password`, `kibana_elasticsearch_password`, `curator_elasticsearch_password`, and `elasticsearch_password`.
 The details of setting these up are discussed in [`playbooks/roles/elasticsearch/README.md`](playbooks/roles/elasticsearch/README.md) and [`playbooks/roles/kibana/README.md`](playbooks/roles/kibana/README.md) respectively.
 The other options necessary will be set by our ansible roles and configuration scripts.
 

--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -25,3 +25,19 @@ elasticsearch_cfg_extra: ""
 # It is templated out to 50-extra-jvm.options
 # Note that this is only supported by recent elasticsearch releases.
 elasticsearch_extra_jvm_options: ""
+
+# Define these and include tasks/create_user_roles.yml to create users and roles in Elasticsearch.
+# Note that Elasticsearch must be running for this to work.
+create_elasticsearch_users: []
+# - username: example_user
+#   password: example_password
+#   roles: ["viewer"]
+create_elasticsearch_roles: []
+# - name: example_role
+#   # Ref https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
+#   permissions: |-
+#     {
+#         "cluster": [...],
+#         "indices": [...],
+#         ...
+#     }

--- a/playbooks/roles/elasticsearch/tasks/create_user_roles.yml
+++ b/playbooks/roles/elasticsearch/tasks/create_user_roles.yml
@@ -1,0 +1,50 @@
+# Create / update the given roles and users
+# 
+# WARNING We don't recommend altering the built-in roles:
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-roles.html
+
+- name: Create Elasticsearch role
+  uri:
+    url: "{{ es_api_uri }}/_security/role/{{ item.name }}"
+    method: POST
+    body_format: json
+    body: "{{ item.permissions }}"
+    status_code: 200
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    force_basic_auth: yes
+    validate_certs: no
+  with_items: "{{ elasticsearch_create_roles }}"
+  when: elasticsearch_create_roles is defined
+
+- name: Create Elasticsearch user
+  uri:
+    url: "{{ es_api_uri }}/_security/user/{{ item.username }}"
+    method: POST
+    body_format: json
+    body:
+      password: "{{ item.password }}"
+      roles: "{{ item.roles }}"
+    status_code: 200
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    force_basic_auth: yes
+    validate_certs: no
+  with_items: "{{ elasticsearch_create_users }}"
+  when: elasticsearch_create_users is defined
+
+# Required because the above creation endpoint will not update passwords for existing users
+- name: Update password for Elasticsearch user
+  uri:
+    url: "{{ es_api_uri }}/_security/user/{{ item.username }}/_password"
+    method: POST
+    body_format: json
+    body:
+      password: "{{ item.password }}"
+    status_code: 200
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    force_basic_auth: yes
+    validate_certs: no
+  with_items: "{{ elasticsearch_create_users }}"
+  when: elasticsearch_create_users is defined


### PR DESCRIPTION
Updates the `curator` role so that it's usable on the ELK stack.

* Updates the curator configuration to allow authentication to TLS Elasticsearch
* Updates the curator action file to ensure that only `filebeat*` indices are deleted.
   (Previously, even system indices were deleted, which broke a lot of things.)
* Creates a user + role with the required permissions to run curator, and documents this new task in `elasticsearch/defaults`
* Runs `curator` as the `curator` system user instead of `root`

**Dependencies**

This PR must be merged before ansible-secrets#, and the deploy hash there updated.

**Testing instructions**

This updated playbook has been applied to logs.opencraft.com, but you're welcome to re-run it from the `ansible-secrets` dir.

```bash
python3.7 -m venv venv
source venv/bin/activate
pip install deploy/requirements.txt  # use these requirements since logs.opencraft.com is still running bionic/18.04
ansible-playbook -vvv deploy/playbooks/elk.yml -l elk-prod --tags curator
```

To test these changes:

1. Shell into the host.
2. Check that `/etc/curator` is owned by `curator:curator`
3. Check that a daily cronjob has been installed for the `curator` user.
4. Ensure that you can run the content of the cronjob as the `curator` user without error.
    If you want to see which indices are deleted, update `/etc/curator/config.yml` to set the log level to `INFO` before running.
    I ran the `curator` cron prior to updating the action.yml on 19/10/2021, and it deleted many `filebeat*` and unfortunately some system indices as well, which broke a lot of things.
    After making these changes, I ran this on 20/10/2021, and it reported only 1 index deleted, as expected:
   ```
   2021-10-20 04:50:39,420 INFO      curator.actions.delete_indices              do_action:670  Deleting 1 selected indices: ['filebeat-2021.04.23']
   ```