### PR TITLE
[BB-4309] fix: mongodb_fresh_deployment variable

### DIFF
--- a/playbooks/roles/mongodb/defaults/main.yml
+++ b/playbooks/roles/mongodb/defaults/main.yml
@@ -29,3 +29,7 @@ MONGODB_EXPORTER_CONSUL_SERVICE:
       - monitor-https
     port: "{{ MONGODB_EXPORTER_PUBLIC_PORT }}"
     enable_tag_override: true
+
+# Used to set mongodb_master on deploying a new replicaSet
+# This must be false to get the primary to connect to the existing replicaSet
+mongodb_fresh_deployment: false


### PR DESCRIPTION
Our MongoDB deployment playbooks make use of a {{mongodb_master}} variable to instruct the playbooks this is the primary in a new replicaSet. But our current reprovisioning/upgrade workflow doesn't fit that case.

This PRs creates a {{mongodb_fresh_deployment}} variable defaulting to {{false}} to ensure this feature is available but turned off by default.

Related PR: https://github.com/open-craft/ansible-secrets/pull/322