### PR TITLE
fix: revert mysql playbook url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/kamaln7/ansible-swapfile
 [submodule "playbooks/roles/geerlingguy.mysql"]
 	path = playbooks/roles/geerlingguy.mysql
-	url = https://github.com/geerlingguy/ansible-role-mysql
+	url = https://github.com/open-craft/ansible-role-mysql
 [submodule "playbooks/roles/geerlingguy.postgresql"]
 	path = playbooks/roles/geerlingguy.postgresql
 	url = https://github.com/geerlingguy/ansible-role-postgresql


### PR DESCRIPTION
## Description

This PR fixes the MySQL playbook GitHub URL. Upstream does not contain the commit hash required by Ocim.

```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git reset --hard 03358d3f180b2e6ffa2a5084f794e09f71884de5 --
  stderr: 'fatal: Could not parse object '03358d3f180b2e6ffa2a5084f794e09f71884de5'.'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/www/opencraft/instance/models/openedx_appserver.py", line 640, in provision
    return self._do_provision()
  File "/var/www/opencraft/instance/models/openedx_appserver.py", line 687, in _do_provision
    raise ProvisioningError("AppServer deploy failed: unhandled exception") from ex
instance.models.openedx_appserver.ProvisioningError: AppServer deploy failed: unhandled exception
```