### PR TITLE
fix: ensure postgres volume condition is correct

### DIFF
--- a/playbooks/roles/postgres/tasks/main.yml
+++ b/playbooks/roles/postgres/tasks/main.yml
@@ -39,7 +39,7 @@
     src: "{{ POSTGRES_OPENSTACK_DB_DEVICE }}"
     fstype: ext4
     state: mounted
-  when: POSTGRES_OPENSTACK_DB_DEVICE
+  when: POSTGRES_OPENSTACK_DB_DEVICE != None
 
 - name: chown & chmod /var/lib/postgresql
   file:


### PR DESCRIPTION
## Description

The condition for checking if the `POSTGRES_OPENSTACK_DB_DEVICE` is not working with ansible `2.8.17` as expected. We need to use `when: POSTGRES_OPENSTACK_DB_DEVICE != None` instead of `when: POSTGRES_OPENSTACK_DB_DEVICE`.