### PR TITLE
chore: update docker-compose from `1.24.0` to `1.29.2` [BB-5587]

### DIFF
--- a/playbooks/roles/docker-compose/tasks/main.yml
+++ b/playbooks/roles/docker-compose/tasks/main.yml
@@ -74,10 +74,10 @@
   tags:
     - docker
 
-# sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+# sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 - name: Install docker-compose
   uri:
-    url: "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-{{ ansible_system }}-{{ ansible_architecture}}"
+    url: "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-{{ ansible_system }}-{{ ansible_architecture}}"
     dest: /usr/local/bin/docker-compose
     status_code: 200, 304
   tags:


### PR DESCRIPTION
Version [`1.26.0`](https://docs.docker.com/compose/release-notes/#1260) started using `python-dotenv` for processing `.env` files, which made parsing quotes consistent.

## Testing instructions
To test SprinCraft, I've done the following checks:
1. Logged into the Django shell and verified that env variables surrounded with quotes (because they contain spaces) do not contain these quotes in their parsed versions, i.e. that `GOOGLE_ROTATIONS_RANGE="Rotation Schedule"` is parsed to `Rotation Schedule`, instead of `"Rotation Schedule"`.

## Author's notes
We could consider upgrading to [v2](https://github.com/docker/compose), but last time I've checked (in November), it didn't work well with Ansible's `compose` module. It might be fixed now, but we're using an older version of Ansible, so we would need to use something like this anyway:
```yaml
- name: Restart services after reconfiguring them
  shell:
    cmd: docker compose stop && docker compose up -d
    chdir: "{{ APP_PATH }}"
```
However, I believe this is outside of the scope here.