### PR TITLE
[SE-5399] Update prometheus server

### DIFF
--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -47,10 +47,17 @@
     name: "{{ COMMON_SERVER_DEPENDENCIES }}"
     state: present
 
+- name: Check if Python3 exists
+  stat:
+      path: "/usr/bin/python3"
+  register: python3_executable
+
 - name: Default to python3
   alternatives:
     name: python
+    link: /usr/bin/python
     path: /usr/bin/python3
+  when: python3_executable.stat.exists
 
 - name: tmpreaper is configured
   template:

--- a/playbooks/roles/prometheus/tasks/grafana.yml
+++ b/playbooks/roles/prometheus/tasks/grafana.yml
@@ -1,13 +1,13 @@
 ---
 
+- name: Grafana – add apt key
+  apt_key:
+    url: https://packages.grafana.com/gpg.key
+
 - name: Grafana – add apt repository
   apt_repository:
     repo: deb https://packages.grafana.com/oss/deb stable main
     filename: grafana
-
-- name: Grafana – add apt key
-  apt_key:
-    url: https://packages.grafana.com/gpg.key
 
 - name: Grafana – install Debian package
   apt:

--- a/playbooks/roles/prometheus/tasks/main.yml
+++ b/playbooks/roles/prometheus/tasks/main.yml
@@ -16,6 +16,11 @@
     src: logrotate
     dest: /etc/logrotate.d/prometheus
 
+- name: ensure prometheus service directory exists
+  file:
+    path: /etc/systemd/system/prometheus.service.d
+    state: directory
+
 - name: set the nofile limit for prometheus service to a high number
   copy:
     content: |


### PR DESCRIPTION
## Description

This PR updates the prometheus playbook to the latest version and ensures we can install Grafana correctly. Also a small issue with python alternatives linking is fixed.

## Testing instructions

1. Add `prometheus-upgrade.net.opencraft.hosting` to `hosts`
2. Copy the `prometheus.net.opencraft.hosting.yml` as `prometheus-upgrade.net.opencraft.hosting.yml`
3. Execute `ansible-playbook -vvv deploy/playbooks/prometheus.yml -l prometheus-upgrade.net.opencraft.hosting`

## Deadline

N/A