### PR TITLE
[SE-5407] fix: adds CORS headers in nginx for 500 and 413 response

### DIFF
--- a/playbooks/roles/nginx-proxy/templates/nginx-proxy.j2
+++ b/playbooks/roles/nginx-proxy/templates/nginx-proxy.j2
@@ -13,6 +13,24 @@ server {
 
     {{ NGINX_PROXY_EXTRA_CONFIG }}
 
+    set $expected_origin false;
+    if ($http_origin ~ {{ NGINX_PROXY_ORIGIN_REGEX }}) {
+    set $expected_origin true;
+    }
+
+    {% for response_code in NGINX_PROXY_CORS_HEADERS_FOR_RESPONSE_CODES %}
+    location @{{ response_code }}_cors_header {
+        if ($expected_origin = true) {
+            add_header 'Access-Control-Allow-Origin' $http_origin always;
+            add_header 'Access-Control-Allow-Methods' 'GET,POST,DELETE,OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+        }
+
+        return {{ response_code }};
+    }
+    {% endfor %}
+
     location / {
         proxy_pass {{ NGINX_PROXY_INTERNAL_SCHEME }}://{{ NGINX_PROXY_INTERNAL_DOMAIN }}:{{ NGINX_PROXY_INTERNAL_PORT }}/;
         proxy_http_version 1.1;
@@ -35,5 +53,9 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         {% endif %}
+
+        {% for response_code in NGINX_PROXY_CORS_HEADERS_FOR_RESPONSE_CODES %}
+        error_page {{ response_code }} = @{{ response_code }}_cors_header;
+        {% endfor %}
     }
 }

--- a/playbooks/roles/ocim/meta/main.yml
+++ b/playbooks/roles/ocim/meta/main.yml
@@ -10,6 +10,8 @@ dependencies:
     NGINX_PROXY_SERVER_NAME: "{{ OPENCRAFT_DOMAIN_NAME }}"
     NGINX_PROXY_SEND_TIMEOUT: 600s
     NGINX_PROXY_READ_TIMEOUT: 600s
+    NGINX_PROXY_ORIGIN_REGEX: '^(http|https)://.*\.opencraft\.com'
+    NGINX_PROXY_CORS_HEADERS_FOR_RESPONSE_CODES: [413, 500]
     NGINX_PROXY_EXTRA_CONFIG: "{{ opencraft_nginx_static_config + opencraft_nginx_websocket_config }}"
     when: www_user != 'vagrant'
 


### PR DESCRIPTION
### Description
413 and 500 response code on `console` server raises CORS issue because of the following reasons:
    - 413: The nginx server doesn't allow request body size < 1 MB and returns 413 response code without any cors header.
    - 500: CORS headers in Django server are handled by `django-cors-headers` middleware but Django structure doesn't allow middleware to attach correct header during 500 errors.
    
 Through this PR we are adding changes to allow Nginx to add correct header for such response code in case the request origin matches the expected pattern.
  
**Ticket link:** https://tasks.opencraft.com/browse/SE-5407


### Testing instructions

__Looking into steps to test this on stage server.__