### PR TITLE
[SE-5457] Group prometheus alerts by alertname.

### DIFF
--- a/playbooks/group_vars/prometheus/public.yml
+++ b/playbooks/group_vars/prometheus/public.yml
@@ -238,6 +238,7 @@ prometheus_alert_manager_config_receivers:
 
 prometheus_alert_manager_config_route:
   receiver: "default"
+  group_by: ["alertname"]
   group_wait: "30s"
   group_interval: "5m"
   repeat_interval: "4h"


### PR DESCRIPTION
Group prometheus alert notifications by "alertname" to bring back the old behavior before our recent prometheus upgrade.

The new version aggregates all alerts in s specified time interval by default, but we want it to split them up by alert type (aka "alertname").

**Ticket**: [SE-5457](https://tasks.opencraft.com/browse/SE-5457)

**Test instructions**:

1. This change was already deployed to prometheus.
2. Verify that the `/etc/prometheus/alertmanager/alertmanager.yml` file on the prometheus server contains the correct `group_by` setting.
3. Verify that email notifications from prometheus to the ops@ mailing list received after Apr 7th, 7:00 AM UTC (when the change was deployed) are clearly separated by alert type -- you should see the alert type in the first position after the "[FIRING:N]" label, for example: "[FIRING:4] low_disk_space_v2 (prod node-exporter warning)".