### PR TITLE
[BB-6098] fix: Whitelisting certbot urls for certificate renewal

### DIFF
--- a/playbooks/roles/wordpress/templates/default-nginx.j2
+++ b/playbooks/roles/wordpress/templates/default-nginx.j2
@@ -14,18 +14,24 @@ server {
         ssl_certificate /etc/letsencrypt/live/{{ LANDING_SITE_HOSTNAME }}/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/{{ LANDING_SITE_HOSTNAME }}/privkey.pem;
 
-	root /var/www/{{ DEFAULT_SITE_HOSTNAME }};
-	index index.html index.php;
+        root /var/www/{{ DEFAULT_SITE_HOSTNAME }};
+        index index.html index.php;
 
         access_log  /var/www/log/{{ DEFAULT_SITE_HOSTNAME }}_nginx_access.log;
         error_log /var/www/log/{{ DEFAULT_SITE_HOSTNAME }}_nginx_error.log error;
 
-	location / {
-		try_files $uri $uri/ =404;
-	}
+        location / {
+                try_files $uri $uri/ =404;
+        }
 
         # deny access to .htaccess files
         location ~ /\.ht {
                 deny  all;
+        }
+
+        # Certbot renewal challenge
+        location ^~ /.well-known/acme-challenge/ {
+                default_type "text/plain";
+                root /var/www/certbot;
         }
 }

--- a/playbooks/roles/wordpress/templates/default-nginx.j2
+++ b/playbooks/roles/wordpress/templates/default-nginx.j2
@@ -1,10 +1,3 @@
-# HTTP
-server {
-	listen *:80;
-	server_name {{ DEFAULT_SITE_HOSTNAME }};
-	return 301 https://$host$request_uri;
-}
-
 # HTTPS
 server {
         listen 443 ssl;
@@ -27,11 +20,5 @@ server {
         # deny access to .htaccess files
         location ~ /\.ht {
                 deny  all;
-        }
-
-        # Certbot renewal challenge
-        location ^~ /.well-known/acme-challenge/ {
-                default_type "text/plain";
-                root /var/www/certbot;
         }
 }

--- a/playbooks/roles/wordpress/templates/maintenance-nginx.j2
+++ b/playbooks/roles/wordpress/templates/maintenance-nginx.j2
@@ -14,18 +14,24 @@ server{
         ssl_certificate /etc/letsencrypt/live/{{ LANDING_SITE_HOSTNAME }}/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/{{ LANDING_SITE_HOSTNAME }}/privkey.pem;
 
-	root /var/www/{{ MAINTENANCE_SITE_HOSTNAME }};
-	index index.html index.php;
+        root /var/www/{{ MAINTENANCE_SITE_HOSTNAME }};
+        index index.html index.php;
 
         access_log  /var/www/log/{{ MAINTENANCE_SITE_HOSTNAME }}_nginx_access.log;
         error_log /var/www/log/{{ MAINTENANCE_SITE_HOSTNAME }}_nginx_error.log error;
 
-	location / {
-		try_files $uri $uri/ =404;
-	}
+        location / {
+                try_files $uri $uri/ =404;
+        }
 
         # deny access to .htaccess files
         location ~ /\.ht {
                 deny  all;
+        }
+
+        # Certbot renewal challenge
+        location ^~ /.well-known/acme-challenge/ {
+                default_type "text/plain";
+                root /var/www/certbot;
         }
 }

--- a/playbooks/roles/wordpress/templates/maintenance-nginx.j2
+++ b/playbooks/roles/wordpress/templates/maintenance-nginx.j2
@@ -1,10 +1,3 @@
-# HTTP
-server {
-	listen *:80;
-        server_name {{ MAINTENANCE_SITE_HOSTNAME }};
-        return 301 https://$host$request_uri;
-}
-
 # HTTPS
 server{
         listen 443 ssl;
@@ -27,11 +20,5 @@ server{
         # deny access to .htaccess files
         location ~ /\.ht {
                 deny  all;
-        }
-
-        # Certbot renewal challenge
-        location ^~ /.well-known/acme-challenge/ {
-                default_type "text/plain";
-                root /var/www/certbot;
         }
 }

--- a/playbooks/roles/wordpress/templates/wordpress-nginx.j2
+++ b/playbooks/roles/wordpress/templates/wordpress-nginx.j2
@@ -1,10 +1,3 @@
-# HTTP
-server {
-        listen *:80;
-        server_name {{ LANDING_SITE_HOSTNAME }} www.{{ LANDING_SITE_HOSTNAME }};
-        return 301 https://$host$request_uri;
-}
-
 # HTTPS
 server {
         listen 443 ssl;
@@ -34,12 +27,6 @@ server {
         # deny access to .htaccess files
         location ~ /\.ht {
                 deny  all;
-        }
-
-        # Certbot renewal challenge
-        location ^~ /.well-known/acme-challenge/ {
-                default_type "text/plain";
-                root /var/www/certbot;
         }
 
         location /files {

--- a/playbooks/roles/wordpress/templates/wordpress-nginx.j2
+++ b/playbooks/roles/wordpress/templates/wordpress-nginx.j2
@@ -24,26 +24,32 @@ server {
                 fastcgi_split_path_info ^(.+?\.php)(/.*)$;
                 if (!-f $document_root$fastcgi_script_name) {
                         return 404;
-                }   
+                }
 
                 fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
                 fastcgi_index index.php;
                 include fastcgi.conf;
-        }   
+        }
 
         # deny access to .htaccess files
         location ~ /\.ht {
                 deny  all;
-        }   
+        }
+
+        # Certbot renewal challenge
+        location ^~ /.well-known/acme-challenge/ {
+                default_type "text/plain";
+                root /var/www/certbot;
+        }
 
         location /files {
                 autoindex off;
                 autoindex_exact_size off;
-                autoindex_localtime on; 
+                autoindex_localtime on;
 
                 #auth_basic "Restricted";
                 #auth_basic_user_file /var/www/.htpasswd_opencraftstaff;
-        }   
+        }
 
         # Wordpress config
         include global/wordpress.conf;


### PR DESCRIPTION
The certbot auto-renewal script was throwing errors at renewal, on investigation we found that certbot looks for a ``well-known/acme-challenge/`` directory which was not present in the webroot so it was throwing a 404 error. On adding  the following lines in ngnix config we set the ``root`` for the URL.

**JIRA tickets**: [BB-6098](https://tasks.opencraft.com/browse/BB-6098)

~~**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

**Dependencies**: None

~~**Screenshots**: Always include screenshots if there is any change to the UI.~~

~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

1. ssh in  ``vm-stage.opencraft.com``
2. sudo su and run ``/snap/bin/certbot renew --dry-run`
3. We should see the all successful certificate regenerating properly
4. If we do `vim /etc/nginx/sites-available/default-stage.opencraft.com.conf`
5. We can see the 
```
       location ^~ /.well-known/acme-challenge/ {
                default_type "text/plain";
                root /var/www/certbot;
        }
```
6. If we remove the above lines  and run ``/snap/bin/certbot renew --dry-run` the renew will fail

**Author notes and concerns**:

I have manually added these lines to all 3 config on vm-stage to test 

**Reviewers**
- [ ] @mtyaka 

