### PR TITLE
feat: adds discourse reaction plugin [BB-5981]

### DIFF
--- a/playbooks/roles/discourse/templates/app.yml.j2
+++ b/playbooks/roles/discourse/templates/app.yml.j2
@@ -96,6 +96,7 @@ hooks:
           - git clone https://github.com/discourse/docker_manager.git
           - git clone https://github.com/discourse/discourse-voting.git
           - git clone https://github.com/discourse/discourse-spoiler-alert.git
+          - git clone https://github.com/discourse/discourse-reactions.git
 
 ## Any custom commands to run after building
 run:
@@ -103,4 +104,6 @@ run:
   ## If you want to set the 'From' email address for your first registration, uncomment and change:
   ## After getting the first signup email, re-comment the line. It only needs to run once.
   - exec: rails r "SiteSetting.notification_email='contact@opencraft.com'"
+  - exec: rails r "SiteSetting.discourse_reactions_enabled='true'"
+  - exec: rails r "SiteSetting.discourse_reactions_enabled_reactions='laughing|open_mouth|cry|angry|thumbsup|thumbsdown'"
   - exec: echo "End of custom commands"

--- a/playbooks/roles/discourse/templates/app.yml.j2
+++ b/playbooks/roles/discourse/templates/app.yml.j2
@@ -105,5 +105,5 @@ run:
   ## After getting the first signup email, re-comment the line. It only needs to run once.
   - exec: rails r "SiteSetting.notification_email='contact@opencraft.com'"
   - exec: rails r "SiteSetting.discourse_reactions_enabled='true'"
-  - exec: rails r "SiteSetting.discourse_reactions_enabled_reactions='laughing|open_mouth|cry|angry|thumbsup|thumbsdown'"
+  - exec: rails r "SiteSetting.discourse_reactions_enabled_reactions='heart|thumbsup|thumbsdown|laughing|open_mouth|cry|angry'"
   - exec: echo "End of custom commands"


### PR DESCRIPTION
### Description
This PR adds discourse-reactions plugin which allows user to add their reactions to the post. ([for more info](https://meta.discourse.org/t/discourse-reactions-beyond-likes/183261))

Link to ticket: https://tasks.opencraft.com/browse/BB-5981

## Testing instructions
- Run a [discourse docker server](https://github.com/bitnami/bitnami-docker-discourse)
- Update the app.yml file with the changes in this PR (to add the plugin and SiteSettings)
- Create a forum and try reacting to a comment.

## Screenshot
![discourse](https://user-images.githubusercontent.com/16653571/163731100-534d85ce-7343-435d-a12e-7185b7abe5c0.gif)

## Reviewer
- [ ] @kaustavb12 