### PR TITLE
Postfix now allows smtp servers without login

### DIFF
--- a/playbooks/roles/postfix/tasks/main.yml
+++ b/playbooks/roles/postfix/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: configure SMTP client password
   copy:
     dest: "{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}"
-    content: "{{ POSTFIX_RELAY_HOST }} {{POSTFIX_RELAY_USER}}:{{POSTFIX_RELAY_PASSWORD}}\n"
+    content: "{{ POSTFIX_RELAY_HOST }} {{POSTFIX_RELAY_USER}}{% if POSTFIX_RELAY_PASSWORD %}:{{POSTFIX_RELAY_PASSWORD}}{% endif %}\n"
     mode: 0600
 
 - name: call postmap on SMTP client password file


### PR DESCRIPTION
## Description

Fixes the content declaration of the Postfix password file so
that it's not invalid if not username or password is defined
so that Google's SMTP relay can be used.

The changes in the PR have already been deployed.

## Supporting information

- https://tasks.opencraft.com/browse/SE-5436
- https://github.com/open-craft/ansible-secrets/pull/368

## Testing instructions

- Check out the `ansible-secrets` repository
- Run the playbook with `ansible-playbook -vvv deploy/playbooks/relay.yml --private-key=~/.ssh/vm.pem -l relay.net.opencraft.hosting.yml`
- Mail should work as normal.

## Deadline

18 April 2022
