### PR TITLE
fix: update haproxy version

### DIFF
--- a/playbooks/roles/load-balancer-v2/defaults/main.yml
+++ b/playbooks/roles/load-balancer-v2/defaults/main.yml
@@ -4,8 +4,8 @@
 
 haproxy_domain_regex: "haproxy.*\\.net\\.opencraft\\.hosting"
 
-haproxy_ppa: "ppa:vbernat/haproxy-1.8"
-haproxy_version: "1.8.*"
+haproxy_ppa: "ppa:vbernat/haproxy-2.4"
+haproxy_version: "2.4.*"
 haproxy_custom_rules: null
 haproxy_custom_maps: []
 


### PR DESCRIPTION
We updated haproxy to use ubuntu 20.04 so we ended up updating haproxy as well

**JIRA tickets**: [SE-5531](https://tasks.opencraft.com/browse/SE-5531)

**Discussions**: https://chat.opencraft.com/opencraft/pl/ewwz7j5gfbn5dyzznru73ud1cr

**Dependencies**: None

~~**Screenshots**: Always include screenshots if there is any change to the UI.~~

~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

Already deployed on haproxy-b-1.net.opencraft.hosting

**Author notes and concerns**:

None

**Reviewers**
- [ ] @viadanna 
