### PR TITLE
feat: adds playbook for cloudwatch aws logs agent setup [BB-6085]

### DIFF
--- a/playbooks/cloudwatch_server_logs.yml
+++ b/playbooks/cloudwatch_server_logs.yml
@@ -1,5 +1,4 @@
 ---
-# Playbook to set up common services on any type of appserver.
 
 - name: Set up aws_logs_agent to send server logs to cloudwatch
   hosts: app

--- a/playbooks/cloudwatch_server_logs.yml
+++ b/playbooks/cloudwatch_server_logs.yml
@@ -1,0 +1,8 @@
+---
+# Playbook to set up common services on any type of appserver.
+
+- name: Set up aws_logs_agent to send server logs to cloudwatch
+  hosts: app
+  become: true
+  roles:
+    - role: aws_logs_agent

--- a/playbooks/roles/aws_logs_agent/defaults/main.yml
+++ b/playbooks/roles/aws_logs_agent/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+AWS_LOGS_AGENT_SCRIPT_URL: "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py"
+CERTBOT_ADDITIONAL_DOMAINS: []
+CERTBOT_OPS_EMAIL: ops@opencraft.com
+CERTBOT_RENEW_OPS_EMAIL: "{{ CERTBOT_OPS_EMAIL }}"
+CERTBOT_NGINX_LISTEN: 80

--- a/playbooks/roles/aws_logs_agent/defaults/main.yml
+++ b/playbooks/roles/aws_logs_agent/defaults/main.yml
@@ -1,7 +1,3 @@
 ---
 
 AWS_LOGS_AGENT_SCRIPT_URL: "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py"
-CERTBOT_ADDITIONAL_DOMAINS: []
-CERTBOT_OPS_EMAIL: ops@opencraft.com
-CERTBOT_RENEW_OPS_EMAIL: "{{ CERTBOT_OPS_EMAIL }}"
-CERTBOT_NGINX_LISTEN: 80

--- a/playbooks/roles/aws_logs_agent/tasks/main.yml
+++ b/playbooks/roles/aws_logs_agent/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Download the AWS Logs Agent python script
+  get_url:
+    url: "{{ AWS_LOGS_AGENT_SCRIPT_URL }}"
+    dest: ./aws-logs-agent.py
+    mode: "1777"
+  tags:
+    - install
+    - install:base
+
+- name: Copy aws_logs_agent.conf template
+  template:
+    src: "aws_logs_agent.conf.j2"
+    dest: "/etc/aws_logs_agent.conf"
+    mode: "0664"
+
+- name: Run AWS Logs Agent script
+  script: /tmp/aws-logs-agent.py --region {{ AWS_EC2_INSTANCE_REGION }} -c /etc/aws_logs_agent.conf
+  args:
+    executable: python3

--- a/playbooks/roles/aws_logs_agent/templates/aws_logs_agent.conf.j2
+++ b/playbooks/roles/aws_logs_agent/templates/aws_logs_agent.conf.j2
@@ -1,0 +1,12 @@
+[general]
+state_file = /var/awslogs/state/agent-state
+
+{% for log_config in log_configs %}
+
+[log_config.file]
+file = log_config.file
+log_group_name = log_config.group_name
+log_stream_name = log_config.stream_name
+datetime_format = %b %d %H:%M:%S
+
+{% endfor %}


### PR DESCRIPTION
## Description

This PR adds a playbook for cloudwatch aws logs agent setup which will be further used for logging server logs to cloudwatch.

**Ticket link:** https://tasks.opencraft.com/browse/BB-6085

## Testing instructions
_Testing is ongoing, expected to update this section once the PR is ready for review._

## Remaining
- [ ] Add a README.md file explaining how/when to use this new playbook.