### PR TITLE
fix: helo for SMTP relay server [SE-5436]

### DIFF
--- a/playbooks/roles/mail/defaults/main.yml
+++ b/playbooks/roles/mail/defaults/main.yml
@@ -46,3 +46,8 @@ POSTFIX_TRANSPORT_CONTENT: ""
 # This is templated out as the contents of the postfix aliases file.
 # See http://www.postfix.org/aliases.5.html for syntax.
 POSTFIX_ALIASES_CONTENT: ""
+
+# This is used for the X-opencraft header to confirm
+# that the email was sent from an OpenCraft Gmail account.
+# Can be configured via: https://admin.google.com/ac/apps/gmail/defaultrouting
+OPENCRAFT_HEADER_TOKEN: null

--- a/playbooks/roles/mail/tasks/main.yml
+++ b/playbooks/roles/mail/tasks/main.yml
@@ -94,6 +94,15 @@
     - "postmap transport"
     - "reload postfix"
 
+- name: Postfix header check maps
+  when: OPENCRAFT_HEADER_TOKEN
+  template:
+    src: "postfix-header-checks.j2"
+    dest: "/etc/postfix/header_checks"
+  notify:
+    - "postmap header_checks"
+    - "reload postfix"
+
 - name: Postfix aliases
   template:
     src: "postfix-aliases.j2"

--- a/playbooks/roles/mail/templates/postfix-header-checks.j2
+++ b/playbooks/roles/mail/templates/postfix-header-checks.j2
@@ -1,0 +1,1 @@
+/^X-opencraft={{OPENCRAFT_HEADER_TOKEN}}/      OK

--- a/playbooks/roles/mail/templates/postfix-main.cf.j2
+++ b/playbooks/roles/mail/templates/postfix-main.cf.j2
@@ -46,3 +46,6 @@ smtpd_tls_key_file = /etc/letsencrypt/live/{{ MAILMAN_WEB_DOMAIN }}/privkey.pem
 smtpd_tls_security_level = may
 smtpd_tls_session_cache_database = btree:${queue_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${queue_directory}/smtp_scache
+{% if OPENCRAFT_HEADER_TOKEN %}
+header_checks = regexp:/etc/postfix/header_checks
+{% endif %}

--- a/playbooks/roles/postfix/templates/main.cf
+++ b/playbooks/roles/postfix/templates/main.cf
@@ -2,6 +2,7 @@ compatibility_level = 2
 
 myorigin = /etc/mailname
 myhostname = {{ POSTFIX_HOSTNAME }}
+smtp_helo_name = {{ POSTFIX_HOSTNAME }}
 inet_interfaces = all
 
 # Mail to receive locally. We should not receive local mail, but keep this here to avoid mail loops.


### PR DESCRIPTION
## Description

This PR contains a fix for the mail relay so that
it adds the correct server when communicating with Google's SMTP
server.

## Supporting information

- Chat thread https://chat.opencraft.com/opencraft/pl/gg5swq9bujdzun9rjbix3nj5cr
- https://tasks.opencraft.com/browse/SE-5436
- https://github.com/open-craft/ansible-secrets/pull/379
- https://gitlab.com/opencraft/documentation/private/-/merge_requests/620

## Testing instructions

- Run `ansible-playbook -vvv deploy/playbooks/relay.yml -l relay.net.opencraft.hosting` [this change is already deployed]
- In the file `/etc/postfix/main.cf` there'll be a line that contains `smtp_helo_name = opencraft.com`

## Deadline

2 May 20221

## Other information