### PR TITLE
[BB-6166] Pin markupsave version in ansible 2.8.17 requirements

### DIFF
--- a/requirements_ansible_2.8.17.txt
+++ b/requirements_ansible_2.8.17.txt
@@ -2,3 +2,4 @@ ansible==2.8.17
 netaddr==0.7.19
 cryptography
 jinja2==2.11.3
+Markupsafe==2.0.1  # jinja2 2.11.3 imports 'soft_unicode' from markup safe which was removed in 2.1.0


### PR DESCRIPTION
## Description

This PR pins the Markupsafe library's version in order for Ansible to deploy using the system Python Version 3.8.

Jinja2 doesn't have version pin on its dependency Markupsafe. Due to
this pip tries to get the latest version of Markupsafe. But Jinja2 is
pinned to 2.11.3 which depends on `soft_unicode`, which was removed from
Markupsafe in version 2.1.0. Hence, this commit pins Markupsafe to the
next lower version - 2.0.1.

## Additional information

- [JIRA Ticket](https://tasks.opencraft.com/browse/BB-6166)
- [Markupsafe 2.1.0 release notes](https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0)