### PR TITLE
fix: Recursively add permission to all the direcrtory

### DIFF
--- a/playbooks/roles/consul/tasks/main.yml
+++ b/playbooks/roles/consul/tasks/main.yml
@@ -30,6 +30,7 @@
     state: directory
     owner: "{{ item.owner }}"
     group: consul
+    recurse: yes
     mode: 0750
   with_items:
     - { path: "{{ consul_config_dir }}", owner: root }


### PR DESCRIPTION
The consul directories were mounted on staging haproxy server,
hence when images are rebuild the permission for the storage is changed.
This make sures that we recursively change permission to the required
one.

**JIRA tickets**: [BB-6188](https://tasks.opencraft.com/browse/BB-6188)

**Discussions**: ~~Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

**Dependencies**: None

~~**Screenshots**: Always include screenshots if there is any change to the UI.~~

~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

Check /var/lib/consul/* permission and group and user should be consul.

**Author notes and concerns**:
None

**Reviewers**
- [ ] @0x29a 
- [ ] @mtyaka 
