### PR TITLE
fix: allow using latest mysql 5.7 version on Ubuntu 20.04

### DIFF
--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -6,6 +6,7 @@ MYSQL_SERVER_BACKUP_DIR: /var/lib/mysql/backup
 MYSQL_OPEN_FILES_LIMIT: 65536
 MYSQL_PROCESSES_LIMIT: 1024
 MYSQL_OPENSTACK_DB_DEVICE: ""
+MYSQL_PINNED_VERSION: ""
 
 # PROMETHEUS ##################################################################
 

--- a/playbooks/roles/mysql/tasks/main.yml
+++ b/playbooks/roles/mysql/tasks/main.yml
@@ -122,6 +122,7 @@
         enabled: yes
 
     - name: Create Consul service definition file
+      when: COMMON_SERVER_INSTALL_CONSUL is defined and COMMON_SERVER_INSTALL_CONSUL
       copy:
         content: "{{ MYSQL_EXPORTER_CONSUL_SERVICE | to_nice_json }}"
         dest: /etc/consul/mysqld-exporter.json
@@ -134,3 +135,10 @@
     state: present
   with_items:
     - "{{MYSQL_URLS}}"
+
+- name: Created pinned version file
+  when: MYSQL_PINNED_VERSION != ""
+  template:
+    src: pinned_versions.j2
+    dest: /etc/apt/preferences.d/mysql
+    mode: 0500

--- a/playbooks/roles/mysql/templates/pinned_versions.j2
+++ b/playbooks/roles/mysql/templates/pinned_versions.j2
@@ -1,0 +1,15 @@
+Package: mysql-server
+Pin: version {{MYSQL_PINNED_VERSION}}
+Pin-Priority: 1001
+
+Package: mysql-client
+Pin: version {{MYSQL_PINNED_VERSION}}
+Pin-Priority: 1001
+
+Package: mysql-community-server
+Pin: version {{MYSQL_PINNED_VERSION}}
+Pin-Priority: 1001
+
+Package: mysql-community-client
+Pin: version {{MYSQL_PINNED_VERSION}}
+Pin-Priority: 1001


### PR DESCRIPTION
## Description

This PR contains changes to upgrade the MySQL version to the latest release in 5.7.

Debian snapshot no longer has the latest versions of mysql 5.6 ad 5.7, so the changes made here are to install the packages from Oracle.

This required a new config var `MYSQL_PINNED_VERSION` that will pin the version of MySQL installed, otherwise the built-in packages will whatever is installed.

## Supporting information

- https://tasks.opencraft.com/browse/SE-5540

## Testing instructions

- The changes have already been deployed to the MySQL servers. Check that `apt upgrade` results in no changes to the MySQL libs even though they're listed when running `apt list --upgradeable`

```bash
ansible-playbook -vvv deploy/playbooks/mysql.yml -l [server]
```

Will deploy the changes

## Deadline

30 May 2022