### PR TITLE
feat: postfix role now supports multiple relays

### DIFF
--- a/playbooks/roles/postfix/defaults/main.yml
+++ b/playbooks/roles/postfix/defaults/main.yml
@@ -14,14 +14,22 @@ POSTFIX_TLS_KEY_CONTENT: ""
 # The domain name of mail originating from the mail server (e.g. monitoring emails)
 POSTFIX_MAILNAME: example.com
 
-# The internal domain.  Mail for this domain will be sent to the internal mail server.
-POSTFIX_INTERNAL_DOMAIN: example.com
-POSTFIX_INTERNAL_MAIL_HOST: "[smtp.example.com]:25"
+# Default outgoing mail server, specified in the format accepted by the Postfix SMTP client
+POSTFIX_RELAY_DEFAULT_HOST: "[smtp.external-provider.com]:587"
 
-# Outgoing mail server, specified in the format accepted by the Postfix SMTP client
-POSTFIX_RELAY_HOST: "[smtp.external-provider.com]:587"
-POSTFIX_RELAY_USER: user
-POSTFIX_RELAY_PASSWORD: password
+# List of senders for the relay, the below will relay
+# all senders from @opencraft.com through Gmail.
+# Example:
+# POSTFIX_RELAY_SENDER_MAP:
+#    - "@opencraft.com      [smtp-relay.gmail.com]:587"
+POSTFIX_RELAY_SENDER_MAP: []
+
+# The list of configured SMTP clients in the format
+# servername:port  username:password
+# Example:
+# POSTFIX_SASL_CLIENT_PASSWORDS:
+#    - "mail.example.com user:securepass"
+POSTFIX_SASL_CLIENT_PASSWORDS: []
 
 # Users who can authenticate against Postfix
 # Example:
@@ -37,3 +45,4 @@ POSTFIX_TLS_CERT: /etc/ssl/certs/postfix-cert.pem
 POSTFIX_TLS_KEY: /etc/ssl/private/postfix.key
 POSTFIX_SASL_CLIENT_PASSWORD_FILE: /etc/postfix/sasl/client-passwd
 POSTFIX_SASL_SERVER_PASSWORD_FILE: /etc/dovecot/private/users
+POSTFIX_RELAY_MAPS_FILE: /etc/postfix/relay_maps

--- a/playbooks/roles/postfix/tasks/main.yml
+++ b/playbooks/roles/postfix/tasks/main.yml
@@ -38,14 +38,23 @@
     dest: /etc/aliases
     src: aliases
 
-- name: configure SMTP client password
-  copy:
+- name: configure sasl client passwords
+  template:
+    src: "client-passwd.j2"
     dest: "{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}"
-    content: "{{ POSTFIX_RELAY_HOST }} {{POSTFIX_RELAY_USER}}{% if POSTFIX_RELAY_PASSWORD %}:{{POSTFIX_RELAY_PASSWORD}}{% endif %}\n"
     mode: 0600
 
-- name: call postmap on SMTP client password file
+- name: call postmap on sasl client password file
   command: postmap "{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}"
+
+- name: configure relay maps
+  template:
+    src: "relay_maps.j2"
+    dest: "{{ POSTFIX_RELAY_MAPS_FILE }}"
+    mode: 0600
+
+- name: call postmap on relay maps file
+  command: postmap "{{ POSTFIX_RELAY_MAPS_FILE }}"
 
 ### Dovecot configuration, used as Postfix SASL authentication backend
 

--- a/playbooks/roles/postfix/templates/client-passwd.j2
+++ b/playbooks/roles/postfix/templates/client-passwd.j2
@@ -1,0 +1,2 @@
+{% for line in POSTFIX_SASL_CLIENT_PASSWORDS %}{{ line }}
+{% endfor %}

--- a/playbooks/roles/postfix/templates/main.cf
+++ b/playbooks/roles/postfix/templates/main.cf
@@ -1,12 +1,10 @@
 compatibility_level = 2
 
+smtp_helo_name = {{ POSTFIX_MAILNAME }}
 myorigin = /etc/mailname
 myhostname = {{ POSTFIX_HOSTNAME }}
-smtp_helo_name = {{ POSTFIX_HOSTNAME }}
 inet_interfaces = all
-
-# Mail to receive locally. We should not receive local mail, but keep this here to avoid mail loops.
-mydestination = $myhostname, localhost.localdomain, localhost
+inet_protocols = ipv4
 
 # Configure SASL authentication via dovecot
 smtpd_sasl_type = dovecot
@@ -15,17 +13,15 @@ smtpd_sasl_local_domain = $myhostname
 smtpd_sasl_security_options = noanonymous
 smtpd_sasl_auth_enable = yes
 
-# Relay mail to internal domains directly to the configured internal mail host
-relay_domains = {{ POSTFIX_INTERNAL_DOMAIN }} $mydestination
-relay_transport = relay:{{ POSTFIX_INTERNAL_MAIL_HOST }}
-
 # Relay mail from authenticated users and mail originating from local machine
+relayhost = {{ POSTFIX_RELAY_DEFAULT_HOST }}
 mynetworks_style = host
 smtpd_relay_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination
-relayhost = {{ POSTFIX_RELAY_HOST }}
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = hash:{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}
 smtp_sasl_security_options = noanonymous
+{% if POSTFIX_RELAY_SENDER_MAP %}sender_dependent_relayhost_maps = hash:{{ POSTFIX_RELAY_MAPS_FILE }}
+{% endif %}
 
 # TLS client settings
 smtp_tls_note_starttls_offer = yes

--- a/playbooks/roles/postfix/templates/relay_maps.j2
+++ b/playbooks/roles/postfix/templates/relay_maps.j2
@@ -1,0 +1,2 @@
+{% for line in POSTFIX_RELAY_SENDER_MAP %}{{ line }}
+{% endfor %}


### PR DESCRIPTION
## Description
We need to able to route internal emails through Gmail and
client emails through AuthSMTP.

The changes in the commit allow setting a default SMTP provider in
addition to routing to a different provider based on the sender
domain.

The changes of note are:

- Rename `POSTFIX_RELAY_HOST` to `POSTFIX_RELAY_DEFAULT_HOST`
- Removing all the internal relays because they're not needed anymore. `mail.opencraft.com` is only used for the mailing lists.
- Generating the `client-passwd` file based on a list of SMTP details instead of assuming only one is provided.

## Supporting information

- https://tasks.opencraft.com/browse/SE-5564

## Testing instructions

See corresponding secrets PR.
