### PR TITLE
feat: use path instead of a different port for Flower in SprinCraft [BB-6393] 

### DIFF
--- a/playbooks/roles/sprintcraft/defaults/main.yml
+++ b/playbooks/roles/sprintcraft/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+SPRINTCRAFT_IMAGE:
 SPRINTCRAFT_VERSION: latest
 APP_PATH: /sprintcraft
 USE_POSTGRES: true

--- a/playbooks/roles/sprintcraft/defaults/main.yml
+++ b/playbooks/roles/sprintcraft/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+SPRINTCRAFT_VERSION: latest
 APP_PATH: /sprintcraft
 USE_POSTGRES: true
 USE_SSL: true

--- a/playbooks/roles/sprintcraft/meta/main.yml
+++ b/playbooks/roles/sprintcraft/meta/main.yml
@@ -7,9 +7,13 @@ dependencies:
     NGINX_PROXY_USE_SSL: "{{ USE_SSL }}"
     NGINX_PROXY_SERVER_NAME: "{{ API_HOSTNAME }}"
     NGINX_PROXY_EXTRA_CONFIG: |
+      # SE-3967 - Prevent Invalid HTTP_HOST headers
+      if ( $host !~* ^{{ all_env_tokens.DJANGO_ALLOWED_HOSTS }}$ ) {
+          return 444;
+      }
+      
       location /flower/ {
-          rewrite ^/flower/(.*)$ /$1 break;
-          proxy_pass http://localhost:5555/;
+          proxy_pass http://localhost:5555/flower/;
           proxy_http_version 1.1;
           proxy_buffering off;
           proxy_request_buffering off;

--- a/playbooks/roles/sprintcraft/templates/docker-compose.yml.j2
+++ b/playbooks/roles/sprintcraft/templates/docker-compose.yml.j2
@@ -8,7 +8,7 @@ volumes:
 
 services:
   django: &django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:django-{{ SPRINTCRAFT_VERSION }}
+    image: registry.gitlab.com/opencraft/dev/sprintcraft{{ SPRINTCRAFT_IMAGE }}:{{ SPRINTCRAFT_VERSION }}
     depends_on:
       {% if USE_POSTGRES %}
       - postgres
@@ -38,19 +38,19 @@ postgres:
 
   celeryworker:
     <<: *django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:celeryworker-{{ SPRINTCRAFT_VERSION }}
+    image: registry.gitlab.com/opencraft/dev/sprintcraft{{ SPRINTCRAFT_IMAGE }}:{{ SPRINTCRAFT_VERSION }}
     ports: []
     command: /start-celeryworker
 
   celerybeat:
     <<: *django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:celerybeat-{{ SPRINTCRAFT_VERSION }}
+    image: registry.gitlab.com/opencraft/dev/sprintcraft{{ SPRINTCRAFT_IMAGE }}:{{ SPRINTCRAFT_VERSION }}
     ports: []
     command: /start-celerybeat
 
   flower:
     <<: *django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:flower-{{ SPRINTCRAFT_VERSION }}
+    image: registry.gitlab.com/opencraft/dev/sprintcraft{{ SPRINTCRAFT_IMAGE }}:{{ SPRINTCRAFT_VERSION }}
     ports:
       - "127.0.0.1:5555:5555"
     command: /start-flower

--- a/playbooks/roles/sprintcraft/templates/docker-compose.yml.j2
+++ b/playbooks/roles/sprintcraft/templates/docker-compose.yml.j2
@@ -8,7 +8,7 @@ volumes:
 
 services:
   django: &django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:django-latest
+    image: registry.gitlab.com/opencraft/dev/sprintcraft:django-{{ SPRINTCRAFT_VERSION }}
     depends_on:
       {% if USE_POSTGRES %}
       - postgres
@@ -23,7 +23,7 @@ services:
 
   {% if USE_POSTGRES %}
 postgres:
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:postgres-latest
+    image: registry.gitlab.com/opencraft/dev/sprintcraft:postgres-{{ SPRINTCRAFT_VERSION }}
     volumes:
       - production_postgres_data:/var/lib/postgresql/data
       - production_postgres_data_backups:/backups
@@ -38,26 +38,26 @@ postgres:
 
   celeryworker:
     <<: *django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:celeryworker-latest
+    image: registry.gitlab.com/opencraft/dev/sprintcraft:celeryworker-{{ SPRINTCRAFT_VERSION }}
     ports: []
     command: /start-celeryworker
 
   celerybeat:
     <<: *django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:celerybeat-latest
+    image: registry.gitlab.com/opencraft/dev/sprintcraft:celerybeat-{{ SPRINTCRAFT_VERSION }}
     ports: []
     command: /start-celerybeat
 
   flower:
     <<: *django
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:flower-latest
+    image: registry.gitlab.com/opencraft/dev/sprintcraft:flower-{{ SPRINTCRAFT_VERSION }}
     ports:
-      - "5555:5555"
+      - "127.0.0.1:5555:5555"
     command: /start-flower
 
   {% if USE_POSTGRES %}
 awscli:
-    image: registry.gitlab.com/opencraft/dev/sprintcraft:awscli-latest
+    image: registry.gitlab.com/opencraft/dev/sprintcraft:awscli-{{ SPRINTCRAFT_VERSION }}
     env_file:
       - .env
     volumes:

--- a/playbooks/roles/sprintcraft/templates/docker-compose.yml.j2
+++ b/playbooks/roles/sprintcraft/templates/docker-compose.yml.j2
@@ -33,7 +33,7 @@ postgres:
   {% endif %}
 
   redis:
-    image: redis:6
+    image: redis:7
     restart: always
 
   celeryworker:


### PR DESCRIPTION
This is a part of the cleanup from https://gitlab.com/opencraft/dev/sprintcraft/-/merge_requests/28.

Thanks to this, we can use SSL with Flower.