### PR TITLE
fix: only write postfix certs if there's content

### DIFF
--- a/playbooks/roles/postfix/tasks/main.yml
+++ b/playbooks/roles/postfix/tasks/main.yml
@@ -11,11 +11,13 @@
 ### Postfix configuration
 
 - name: copy TLS certificate
+  when: POSTFIX_TLS_CERT_CONTENT != ""
   copy:
     dest: "{{ POSTFIX_TLS_CERT }}"
     content: "{{ POSTFIX_TLS_CERT_CONTENT }}"
 
 - name: copy TLS private key
+  when: POSTFIX_TLS_KEY_CONTENT != ""
   copy:
     dest: "{{ POSTFIX_TLS_KEY }}"
     content: "{{ POSTFIX_TLS_KEY_CONTENT }}"


### PR DESCRIPTION
## Description

Fixes the conditional when writing relay certificates so that they don't write anything if there's no content.

## Testing instructions

In related PR.