### PR TITLE
chore: remove python3.6 and use system installed python 3.8

### DIFF
--- a/playbooks/roles/cert-manager/tasks/main.yml
+++ b/playbooks/roles/cert-manager/tasks/main.yml
@@ -1,21 +1,11 @@
 ---
-
-- name: Add the `deadsnakes` PPA for getting Python3.6 on Ubuntu 16.04
-  apt_repository:
-    repo: 'ppa:deadsnakes/ppa'
-
-- name: Download Python3.6
+- name: Install pip
   apt:
-    name: python3.6
-
-- name: Download pip3.6
-  shell:
-    cmd: curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6
+    name: python3-pip
 
 - name: Install pipenv to later install python dependencies and virtual environments.
   pip:
     name: pipenv
-    executable: pip3.6
   become: true
 
 - name: Download cert-manager


### PR DESCRIPTION
## Description

This PR updates cert-manager to run on Ubuntu 20.04 **only**. To achieve this, cert-manager was made to work with Python3.8 in [this PR](https://github.com/open-craft/cert-manager/pull/24).

## Testing instructions

### Part 1
Run the playbook from the secrets repo.

`ansible-playbook -vvv deploy/playbooks/cert-manager.yml -l cert-manager-stage.net.opencraft.hosting.yml`

There should be no errors.

### Part 2
The changes have already been deployed to `cert-manager-stage.net.opencraft.hosting`. 

- Create a sandbox on https://stage.manage.opencraft.com 
- SSH onto the server
- Verify that your new sandbox's certificate shows up in `/etc/letsencrypt/live/` within about 5 minutes or so after creation.