### PR TITLE
Fix an error in the sanity checker [MNG-3199]

### DIFF
--- a/playbooks/roles/sanity-checker/files/sanity_check.py
+++ b/playbooks/roles/sanity-checker/files/sanity_check.py
@@ -87,6 +87,8 @@ def send_message(recipient, subject, body):
     While sending mail is not reliable, mail delivery is async, and mail always
     exits successfully.
     """
+    if isinstance(body, str):
+        body = body.encode()
     process = subprocess.Popen(['mail', '-s', subject, recipient], stdin=subprocess.PIPE)
     process.communicate(body)
 


### PR DESCRIPTION
@gabor-boros @keithgg We got an alert from Dead Man's Snitch that our mail server's sanity check was failing to report in. The mail queue was full _and_ it couldn't alert us about this because of this error:

```
Traceback (most recent call last):
  File "/usr/local/sbin/sanity-check.py", line 225, in <module>
    sanity_check(json_data)
  File "/usr/local/sbin/sanity-check.py", line 195, in sanity_check
    send_message(json_data['send_report_to'], json_data['subject'], report_text)
  File "/usr/local/sbin/sanity-check.py", line 92, in send_message
    process.communicate(body)
  File "/usr/lib/python3.8/subprocess.py", line 1013, in communicate
    self._stdin_write(input)
  File "/usr/lib/python3.8/subprocess.py", line 962, in _stdin_write
    self.stdin.write(input)
TypeError: a bytes-like object is required, not 'str'
mail: Null message body; hope that's ok
```

I have confirmed that this PR fixed the issue on the mail server. However I don't think it's Python 2 compatible - is that OK?