### PR TITLE
fix: permissions on dovecot directory

### DIFF
--- a/playbooks/roles/postfix/defaults/main.yml
+++ b/playbooks/roles/postfix/defaults/main.yml
@@ -45,4 +45,5 @@ POSTFIX_TLS_CERT: /etc/ssl/certs/postfix-cert.pem
 POSTFIX_TLS_KEY: /etc/ssl/private/postfix.key
 POSTFIX_SASL_CLIENT_PASSWORD_FILE: /etc/postfix/sasl/client-passwd
 POSTFIX_SASL_SERVER_PASSWORD_FILE: /etc/dovecot/private/users
+POSTFIX_SASL_SERVER_PASSWORD_DIRECTORY: /etc/dovecot/private/
 POSTFIX_RELAY_MAPS_FILE: /etc/postfix/relay_maps

--- a/playbooks/roles/postfix/tasks/main.yml
+++ b/playbooks/roles/postfix/tasks/main.yml
@@ -70,6 +70,13 @@
     dest: /etc/dovecot/conf.d/10-auth.conf
     src: dovecot-auth.conf
 
+- name: write Dovecot password directory
+  file:
+    path: "{{POSTFIX_SASL_SERVER_PASSWORD_DIRECTORY}}"
+    state: directory
+    owner: dovecot
+    group: dovecot
+
 - name: generate Dovecot password hashes
   command: "doveadm pw -s SHA512-CRYPT -p {{ item.password }}"
   register: dovecot_users


### PR DESCRIPTION
## Description

Fixes the permissions on the dovecot directory. When a new server is deployed without this change, there'll be an error message:

```
Aug 16 12:53:08 relay dovecot: auth: Error: passwd-file(discourse,54.38.245.59): stat(/etc/dovecot/private/users) failed: Permission denied (euid=114(dovecot) egid=123(dovecot) missing +x perm: /etc/dovecot/private, dir owned by 0:0 mode=0700)
```
This PR correct the user on the directory so that it can be read.

## Testing instructions

In the secrets repo.