### PR TITLE
fix: header_checks didn't have a handler

### DIFF
--- a/playbooks/roles/mail/defaults/main.yml
+++ b/playbooks/roles/mail/defaults/main.yml
@@ -50,4 +50,4 @@ POSTFIX_ALIASES_CONTENT: ""
 # This is used for the X-opencraft header to confirm
 # that the email was sent from an OpenCraft Gmail account.
 # Can be configured via: https://admin.google.com/ac/apps/gmail/defaultrouting
-OPENCRAFT_HEADER_TOKEN: null
+OPENCRAFT_HEADER_TOKEN: ""

--- a/playbooks/roles/mail/handlers/main.yml
+++ b/playbooks/roles/mail/handlers/main.yml
@@ -36,3 +36,8 @@
   service:
     name: postfix
     state: reloaded
+
+# Update the postfix header checks db
+# This should be run whenever /etc/postfix/header_checks is changed.
+- name: postmap header_checks
+  command: "postmap /etc/postfix/header_checks"

--- a/playbooks/roles/mail/tasks/main.yml
+++ b/playbooks/roles/mail/tasks/main.yml
@@ -95,7 +95,7 @@
     - "reload postfix"
 
 - name: Postfix header check maps
-  when: OPENCRAFT_HEADER_TOKEN
+  when: OPENCRAFT_HEADER_TOKEN != ""
   template:
     src: "postfix-header-checks.j2"
     dest: "/etc/postfix/header_checks"


### PR DESCRIPTION
## Description
Fixes an issue when deploying the `mail.yml` role. `OPENCRAFT_HEADER_TOKEN` cannot be used in a `when` statement when the value is `null`.

Also adds the handler for the `postmap transport` that was missing.

## Testing instructions

I've added `mail-test.net.opencraft.hosting` in the commit https://github.com/open-craft/ansible-secrets/commit/3feae9ab01d7c85acc6274a86f49cfd35fc75299

Check out the branch `keith/fix-postfix-header-checks` here and in the secrets repo and deploy:

```bash
ansible-playbook -vvv deploy/playbooks/mail.yml -l mail-test.net.opencraft.hosting --private-key=~/.ssh/vm.pem
```

Without these changes you will get an error.