### PR TITLE
[SE-5766] Remove references to tmpreaper.

### DIFF
--- a/playbooks/group_vars/ocim/public.yml
+++ b/playbooks/group_vars/ocim/public.yml
@@ -4,10 +4,6 @@
 
 COMMON_SERVER_NO_BACKUPS: true
 
-# Ocim uses many temporary files.
-# Increase tmpreaper runtime since the default often isn't enough.
-TMPREAPER_RUNTIME: '180'
-
 # CERTBOT #####################################################################
 
 CERTBOT_ADDITIONAL_DOMAINS:

--- a/playbooks/roles/common-server-init/defaults/main.yml
+++ b/playbooks/roles/common-server-init/defaults/main.yml
@@ -1,5 +1,1 @@
 COMMON_SERVER_INSTALL_NGINX: true
-
-# Default tmpreaper runtime limit is 55 seconds.
-# This often isn't enough, so increase by default.
-TMPREAPER_RUNTIME: '110'

--- a/playbooks/roles/common-server-init/tasks/misc.yml
+++ b/playbooks/roles/common-server-init/tasks/misc.yml
@@ -59,11 +59,6 @@
     path: /usr/bin/python3
   when: python3_executable.stat.exists
 
-- name: tmpreaper is configured
-  template:
-    src: tmpreaper.conf
-    dest: /etc/tmpreaper.conf
-
 - name: Copy security update check script
   copy:
     src: security_updates_checker.sh

--- a/playbooks/roles/common-server-init/templates/tmpreaper.conf
+++ b/playbooks/roles/common-server-init/templates/tmpreaper.conf
@@ -1,7 +1,0 @@
-# {{ ansible_managed }}
-# docs: `man 5 tmpreaper` or https://manpages.ubuntu.com/manpages/focal/man5/tmpreaper.conf.5.html
-
-TMPREAPER_PROTECT_EXTRA=''
-TMPREAPER_DIRS='/tmp/.'
-TMPREAPER_DELAY='256'
-TMPREAPER_ADDITIONALOPTIONS='--runtime={{ TMPREAPER_RUNTIME }}'

--- a/playbooks/roles/common-server/defaults/main.yml
+++ b/playbooks/roles/common-server/defaults/main.yml
@@ -77,7 +77,6 @@ COMMON_SERVER_DEPENDENCIES:
   - unzip
   - chkrootkit
   - etckeeper
-  - tmpreaper
   - ufw
   - apt-show-versions
 


### PR DESCRIPTION
We discovered that tmpreaper doesn't work well together with chkrootkit which (among other things) periodically scans contents of temporary files, thereby updating files' atime values and preventing tmpreaper from being able to purge old files based on their access timestamps.

Since the combination was never working, and we want to keep using chkrootkit, we decided to remove tmpreaper and manually clean up temporary files when disk space gets low.

Note that on the vast majority of our servers/VMs, the amount of temporary files is tiny, with one of the few exceptions being VMs that run Ocim.

**Testing**

1. Checkout this branch and run `ansible-playbook -l ocim-stage deploy/playbooks/ocim.yml --tags=common-server`
2. Verify that the playbook runs successfully, and does not install `tmpreaper` (I manually removed it from Ocim stage).