### PR TITLE
chore: ssl fixes

### DIFF
--- a/playbooks/group_vars/vault/public.yml
+++ b/playbooks/group_vars/vault/public.yml
@@ -11,7 +11,7 @@ vault_tls_dir: "{{ vault_config_dir }}/tls"
 vault_server_scheme: "https"
 
 # Listener stanza
-vault_tcp_address: "0.0.0.0:8200"
+vault_tcp_address: "127.0.0.1:8199"
 vault_tcp_cluster_address: "0.0.0.0:8201"
 vault_tcp_tls_cert_file: "{{ vault_tls_dir }}/cert.pem"
 vault_tcp_tls_key_file: "{{ vault_tls_dir }}/key.pem"

--- a/playbooks/group_vars/vault/public.yml
+++ b/playbooks/group_vars/vault/public.yml
@@ -11,8 +11,8 @@ vault_tls_dir: "{{ vault_config_dir }}/tls"
 vault_server_scheme: "https"
 
 # Listener stanza
-vault_tcp_address: "127.0.0.1:8199"
-vault_tcp_cluster_address: "0.0.0.0:8201"
+vault_tcp_address: "0.0.0.0:8198"
+vault_tcp_cluster_address: "0.0.0.0:8199"
 vault_tcp_tls_cert_file: "{{ vault_tls_dir }}/cert.pem"
 vault_tcp_tls_key_file: "{{ vault_tls_dir }}/key.pem"
 vault_tcp_tls_client_ca_file: "{{ vault_tls_dir }}/ca.pem"
@@ -20,7 +20,7 @@ vault_tcp_tls_client_ca_file: "{{ vault_tls_dir }}/ca.pem"
 # Env
 vault_env_base:
   VAULT_LOG_LEVEL: debug
-  VAULT_ADDR: "{{ vault_server_scheme }}://127.0.0.1:8200"
+  VAULT_ADDR: "{{ vault_server_scheme }}://127.0.0.1:8198"
   VAULT_CACERT: "{{ vault_tcp_tls_client_ca_file }}"
   VAULT_CLIENT_CERT: "{{ vault_tcp_tls_cert_file }}"
   VAULT_CLIENT_KEY: "{{ vault_tcp_tls_key_file }}"

--- a/playbooks/roles/load-balancer-v2/defaults/main.yml
+++ b/playbooks/roles/load-balancer-v2/defaults/main.yml
@@ -4,7 +4,13 @@
 
 haproxy_domain_regex: "haproxy.*\\.net\\.opencraft\\.hosting"
 vault_domain_regex: "vault.*\\.net\\.opencraft\\.hosting"
-vault_port: "8199"
+internal_vault_port: "8198"
+external_vault_port: "8200"
+
+internal_vault_cluster_port: "8199"
+external_vault_cluster_port: "8201"
+
+hsts_timeout_seconds: 16000000
 
 haproxy_ppa: "ppa:vbernat/haproxy-2.4"
 haproxy_version: "2.4.*"

--- a/playbooks/roles/load-balancer-v2/defaults/main.yml
+++ b/playbooks/roles/load-balancer-v2/defaults/main.yml
@@ -3,6 +3,8 @@
 # HAPROXY #####################################################################
 
 haproxy_domain_regex: "haproxy.*\\.net\\.opencraft\\.hosting"
+vault_domain_regex: "vault.*\\.net\\.opencraft\\.hosting"
+vault_port: "8199"
 
 haproxy_ppa: "ppa:vbernat/haproxy-2.4"
 haproxy_version: "2.4.*"

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -66,9 +66,16 @@ frontend fe_https
     acl backend_fail status 500:599
     acl error_backend res.hdr(X-Maintenance) yes
     acl maint_backend req.hdr(host),lower,map_dom(/etc/haproxy/maint.map) -m found
+    {% if haproxy_enable_stats_page %}
+    acl lb_domain hdr_reg(host) -i {{! haproxy_domain_regex !}}
+    {% endif %}
+
     http-response redirect location /error if backend_fail !error_backend
     use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/maint.map)] if maint_backend
     use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/backend.map)]
+    {% if haproxy_enable_stats_page %}
+    use_backend proxy_stats if lb_domain { path_beg /stats }
+    {% endif
 
     # For errors raised by HAProxy redirect to /error so they will go to the error backend.
     errorloc 500 /error
@@ -77,8 +84,7 @@ frontend fe_https
     errorloc 504 /error
 
 {% if haproxy_enable_stats_page %}
-frontend stats
-    bind *:{{! haproxy_stats_port !}} ssl crt /etc/haproxy/certs.pem crt /etc/haproxy/certs
+backend proxy_stats
     stats enable
     stats uri /stats
     stats refresh 10s

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -91,6 +91,19 @@ backend proxy_stats
     stats auth {{! haproxy_stats_page_username !}}:{{! haproxy_stats_page_password !}}
 {% endif %}
 
+{% if vault_domain_regex %}
+frontend fe_vault
+    bind *:8200
+    option tcplog
+    mode tcp
+    acl vault_domain hdr_reg(host) -i {{! vault_domain_regex !}}
+    use_backend be_vault if vault_domain
+
+backend be_vault
+    mode tcp
+    server vault-local 127.0.0.1:{{vault_port}}
+{% endif %}
+
 backend be_acme_challenge
     server srv_lets_encrypt {{! cert_manager_server_address !}}
 

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -47,6 +47,7 @@ frontend fe_http
     bind *:80
     acl lb_domain hdr_reg(host) -i {{! haproxy_domain_regex !}}
     acl acme_challenge path_beg /.well-known/acme-challenge/
+    http-response set-header Strict-Transport-Security "max-age={{! hsts_timeout_seconds !}}; preload;" if !acme_challenge
     redirect scheme https code 301 unless acme_challenge
     use_backend be_acme_challenge_local if lb_domain
     use_backend be_acme_challenge if acme_challenge
@@ -75,7 +76,8 @@ frontend fe_https
     use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/backend.map)]
     {% if haproxy_enable_stats_page %}
     use_backend proxy_stats if lb_domain { path_beg /stats }
-    {% endif
+    {% endif %}
+    http-response set-header Strict-Transport-Security "max-age={{! hsts_timeout_seconds !}}; preload;"
 
     # For errors raised by HAProxy redirect to /error so they will go to the error backend.
     errorloc 500 /error
@@ -93,15 +95,29 @@ backend proxy_stats
 
 {% if vault_domain_regex %}
 frontend fe_vault
-    bind *:8200
-    option tcplog
+    bind *:{{! external_vault_port !}}
+    bind *:{{! external_vault_cluster_port !}}
     mode tcp
-    acl vault_domain hdr_reg(host) -i {{! vault_domain_regex !}}
-    use_backend be_vault if vault_domain
+    option tcplog
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+
+    acl is_vault_domain req.ssl_sni -m reg -i {{! vault_domain_regex !}}
+    acl is_vault_port dst_port {{! external_vault_port !}}
+    acl is_vault_cluster_port dst_port {{! external_vault_cluster_port !}}
+
+    use_backend be_vault if is_vault_domain is_vault_port
+    use_backend be_vault_cluster if is_vault_domain is_vault_cluster_port
+    default_backend error
 
 backend be_vault
     mode tcp
-    server vault-local 127.0.0.1:{{vault_port}}
+    server vault-local 127.0.0.1:{{! internal_vault_port !}}
+
+backend be_vault_cluster
+    mode tcp
+    server vault-local 127.0.0.1:{{! internal_vault_cluster_port !}}
+
 {% endif %}
 
 backend be_acme_challenge


### PR DESCRIPTION
## Description

1. Stats page is only available via HAProxy domains
2. Limit vault access to vault domains
   This was not completely possible as `vault` terminates SSL connections itself. This meant that we have to keep the vault port open. However, the change in this PR limits access vault to only `vault` domains.
- Add HSTS headers

## Testing instructions

The changes in this PR have already been deployed to the staging haproxy servers.

WRT to issues mentioned in the description, they can be reproduced by using any domain that had been provisioned on the webserver. For testing purposes, we'll use https://oc-5456.stage.opencraft.hosting

### Stats pages

Visit https://oc-5456.stage.opencraft.hosting:8404, you should get a connection refused error. You should be able to view the stats by going to http://haproxy-stage.net.opencraft.hosting/stats

### Limit vault access

Previously it was possible to go to https://oc-5456.stage.opencraft.hosting:8200 and get back the vault UI. This should no longer be the case (ie. if you're using FF your browser will not use the certificate you loaded).

### Add HSTS headers

These headers are now on any appserver that has been loaded on staging. To test, load any site and view the `Strict-Transport-Security` header.