### PR TITLE
feat: block abusive ips on haproxy

### DIFF
--- a/playbooks/roles/load-balancer-v2/defaults/main.yml
+++ b/playbooks/roles/load-balancer-v2/defaults/main.yml
@@ -61,3 +61,5 @@ haproxy_exporter_consul_service:
       - monitor-https
     port: 19101
     enable_tag_override: true
+
+haproxy_blocked_ips: []

--- a/playbooks/roles/load-balancer-v2/tasks/main.yml
+++ b/playbooks/roles/load-balancer-v2/tasks/main.yml
@@ -131,6 +131,15 @@
   with_items: "{{ haproxy_custom_rules }}"
   when: haproxy_custom_rules
 
+- name: Copy over the blocklist if defined
+  template:
+    src: "blacklisted-ips.j2"
+    dest: "/etc/haproxy/blacklisted-ips"
+    mode: "0644"
+  when:
+    haproxy_blocked_ips is iterable and haproxy_blocked_ips|length > 0
+  tags: 'haproxy-config'  
+
 - name: Copy over extra certs for prod
   # HAProxy will serve, for any given domain, the first matching cert it finds.
   # If it finds no matching cert, it will serve the first cert it finds, period.

--- a/playbooks/roles/load-balancer-v2/templates/blacklisted-ips.j2
+++ b/playbooks/roles/load-balancer-v2/templates/blacklisted-ips.j2
@@ -1,0 +1,2 @@
+{% for ip in haproxy_blocked_ips %}{{ip}}
+{% endfor %}

--- a/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
+++ b/playbooks/roles/load-balancer-v2/templates/haproxy.cfg.ctmpl
@@ -47,6 +47,12 @@ frontend fe_http
     bind *:80
     acl lb_domain hdr_reg(host) -i {{! haproxy_domain_regex !}}
     acl acme_challenge path_beg /.well-known/acme-challenge/
+    
+    {% if haproxy_blocked_ips %}
+    acl is-blocked-ip src -f /etc/haproxy/blacklisted-ips
+    http-request deny deny_status 429 if is-blocked-ip
+    {% endif %}
+    
     http-response set-header Strict-Transport-Security "max-age={{! hsts_timeout_seconds !}}; preload;" if !acme_challenge
     redirect scheme https code 301 unless acme_challenge
     use_backend be_acme_challenge_local if lb_domain
@@ -54,6 +60,11 @@ frontend fe_http
 
 frontend fe_https
     bind *:443 ssl crt /etc/haproxy/certs.pem crt /etc/haproxy/certs crt /etc/haproxy/certs/ocim
+
+    {% if haproxy_blocked_ips %}
+    acl is-blocked-ip src -f /etc/haproxy/blacklisted-ips
+    http-request deny deny_status 429 if is-blocked-ip
+    {% endif %}
 
     # X-Forwarded-For is added by "option forwardfor"
     http-request set-header X-Forwarded-Port %[dst_port]


### PR DESCRIPTION
## Description

Adds the ability to HAProxy to block abusive IPs. To configure add the relevant IP to the `haproxy_blocked_ips` array.

## Testing instructions

Run this command. It will route through `haproxy-stage-1` for `mapnutmeg.stage.opencraft.hosting` and give you the heartbeat output.

- Verify SSL works (you should get the heartbeat response)
```
curl --insecure --resolve 'mapnutmeg.stage.opencraft.hosting:443:145.239.14.5' https://mapnutmeg.stage.opencraft.hosting/heartbeat?extended
```
- Verify HTTP works (you should get a 404)
```
curl -L --resolve 'mapnutmeg.stage.opencraft.hosting:80:145.239.14.5' http://mapnutmeg.stage.opencraft.hosting/.well-known/acme-challenge/
```
Add your IP to the `haproxy_blocked_ips` array and deploy `haproxy-stage-1` (I comment out `common-server` and `node-exporter` to make it faster)

```bash
ansible-playbook -vvv deploy/playbooks/load-balancer-v2.yml -l haproxy-stage-1.net.opencraft.hosting
```

Run the `curl` commands again. You will get a `Too many requests error` for both.
