### PR TITLE
refactor: add fluent-bit index name

### DIFF
--- a/playbooks/roles/fluent-bit/defaults/main.yml
+++ b/playbooks/roles/fluent-bit/defaults/main.yml
@@ -17,6 +17,7 @@ fluentbit_opensearch_output:
     Port: "{{ fluentbit_port }}"
     HTTP_Passwd: "{{ fluentbit_password }}"
     HTTP_User: "{{ fluentbit_user }}"
+    Index: fluent-bit-logs
     Logstash_Format: Off
     Replace_Dots: On
     Retry_Limit: False


### PR DESCRIPTION
This PR adds an index name for fluent-bit logs to be able to identify logs easier and setup log cleanup on OpenSearch side.