### PR TITLE
fix: ensure ubuntu 22.04 is supported on DO

### DIFF
--- a/playbooks/roles/common-server-init/handlers/main.yml
+++ b/playbooks/roles/common-server-init/handlers/main.yml
@@ -2,12 +2,7 @@
 
 - name: restart networking
   service:
-    name: >-
-      {%- if ansible_distribution == "Ubuntu" and ansible_distribution_release in ["bionic", "focal", "nobel"] -%}
-      systemd-networkd
-      {%- else -%}
-      networking
-      {%- endif %}
+    name: systemd-networkd
     state: restarted
 
 - name: reload nginx

--- a/playbooks/roles/docker-compose/tasks/main.yml
+++ b/playbooks/roles/docker-compose/tasks/main.yml
@@ -43,7 +43,7 @@
 # sudo apt-get install *
 - name: Remove python3-yaml
   apt:
-    name: ['python3-yaml', 'jsonschema']
+    name: ['python3-yaml', 'python3-jsonschema']
     state: absent
   tags:
     - docker
@@ -62,7 +62,7 @@
     - docker==6.1.3
     - docker-compose==1.29.2
     - requests==2.31.0
-    extra_args: --break-system-packages
+    extra_args: --break-system-packages --no-build-isolation
   tags:
     - docker
 


### PR DESCRIPTION
This PR ensures that we can install docker on Ubuntu Nobel. Also, removes some instructions that would be applied on <bionic instances, that we don't have anymore.