### PR TITLE
chore: block requests from unknown hosts to accounting application

### DIFF
--- a/playbooks/roles/accounting/templates/accounting-nginx.j2
+++ b/playbooks/roles/accounting/templates/accounting-nginx.j2
@@ -1,7 +1,7 @@
 server {
     listen 443 ssl;
 
-    server_name {{ ACCOUNTING_DOMAIN_NAME }} www.{{ ACCOUNTING_DOMAIN_NAME }};
+    server_name {{ ACCOUNTING_DOMAIN_NAME }};
 
     # Block requests not coming from the accounting domain
     if ( $host !~* ^{{ ACCOUNTING_DOMAIN_NAME }}$ ) {
@@ -9,10 +9,6 @@ server {
     }
     if ( $http_host !~* ^{{ ACCOUNTING_DOMAIN_NAME }}$ ) {
         return 444;
-    }
-
-    if ($host = www.{{ ACCOUNTING_DOMAIN_NAME }}) {
-        rewrite ^(.*)$ https://{{ ACCOUNTING_DOMAIN_NAME }}$1 permanent;
     }
 
     ssl on;

--- a/playbooks/roles/accounting/templates/accounting-nginx.j2
+++ b/playbooks/roles/accounting/templates/accounting-nginx.j2
@@ -3,6 +3,14 @@ server {
 
     server_name {{ ACCOUNTING_DOMAIN_NAME }} www.{{ ACCOUNTING_DOMAIN_NAME }};
 
+    # Block requests not coming from the accounting domain
+    if ( $host !~* ^{{ ACCOUNTING_DOMAIN_NAME }}$ ) {
+        return 444;
+    }
+    if ( $http_host !~* ^{{ ACCOUNTING_DOMAIN_NAME }}$ ) {
+        return 444;
+    }
+
     if ($host = www.{{ ACCOUNTING_DOMAIN_NAME }}) {
         rewrite ^(.*)$ https://{{ ACCOUNTING_DOMAIN_NAME }}$1 permanent;
     }


### PR DESCRIPTION
## Description

Adds rules to nginx configs to block requests not coming from know hosts to the accounting app.

## Testing

1. The modified nginx config is deployed in stage.billing.opencraft.com
2. The url `bad-hostname-test.opencraft.hosting` in currently pointing to stage billing server's IP
3. Try hitting this URL, the request should get blocked by nginx


## Other information

[SE-6310](https://tasks.opencraft.com/browse/SE-6310)